### PR TITLE
Add DEFAULT_MAX_WORKERS constant and enhance worker limit tests

### DIFF
--- a/src/sflkit/runners/run.py
+++ b/src/sflkit/runners/run.py
@@ -25,6 +25,8 @@ PYTEST_RESULT_PATTERN = re.compile(
 
 DEFAULT_TIMEOUT = 10
 
+DEFAULT_MAX_WORKERS = 64
+
 
 class TestResult(enum.Enum):
     PASSING = "PASSING"
@@ -57,7 +59,7 @@ class Runner(abc.ABC):
         self.thread_support = thread_support
 
     @staticmethod
-    def use_parallel() -> "Runner":
+    def use_parallel() -> type["Runner"]:
         raise NotImplementedError()
 
     def get_tests(
@@ -103,7 +105,7 @@ class Runner(abc.ABC):
         for test_result in TestResult:
             (output / test_result.get_dir()).mkdir(parents=True, exist_ok=True)
         for event_file, test in enumerate(tests):
-            test_result = self.run_test(directory, test, environ=environ)
+            test_result = self.run_test(directory, test, environ=environ, python=python)
             self.tests[test_result].add(test)
             if os.path.exists(directory / "EVENTS_PATH"):
                 shutil.move(
@@ -135,7 +137,14 @@ class Runner(abc.ABC):
             directory,
             output,
             self.filter_tests(
-                self.get_tests(directory, files=files, base=base, environ=environ, k=k)
+                self.get_tests(
+                    directory,
+                    files=files,
+                    base=base,
+                    environ=environ,
+                    python=python,
+                    k=k,
+                )
             ),
             environ=environ,
             python=python,
@@ -579,7 +588,7 @@ class ParallelPytestRunner(PytestRunner):
         super().__init__(
             re_filter, timeout, set_python_path, thread_support=thread_support
         )
-        self.workers = max(min(workers, os.cpu_count() or 512), 1)
+        self.workers = max(min(workers, os.cpu_count() or DEFAULT_MAX_WORKERS), 1)
         self.is_parallel = True
         self.environ = None
         self.python = None
@@ -645,7 +654,7 @@ class ParallelInputRunner(InputRunner):
         thread_support: bool = False,
     ):
         super().__init__(access, passing, failing, thread_support=thread_support)
-        self.workers = max(min(workers, os.cpu_count() or 512), 1)
+        self.workers = max(min(workers, os.cpu_count() or DEFAULT_MAX_WORKERS), 1)
         self.is_parallel = True
         self.environ = None
         self.python = None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,6 @@
 import os
-import time
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 from sflkit import Config, instrument_config, Analyzer
 from sflkit.analysis.analysis_type import AnalysisType
@@ -180,3 +180,71 @@ class RunnerTests(BaseTest):
             os.path.join("structure", "tests", "test_a.py::test_c"),
             tests,
         )
+
+    def test_runner_python_interpreter(self):
+        """
+        Test that the python argument is correctly passed to subprocess calls.
+        This test verifies that pytest collection uses the specified python
+        interpreter instead of the default 'python3'.
+        """
+        custom_python = "python3.11"
+
+        # Create a mock for subprocess.run
+        with patch("sflkit.runners.run.subprocess.run") as mock_run:
+            # Create a mock return value that simulates pytest collection output
+            mock_process = MagicMock()
+            mock_process.returncode = 0
+            mock_process.stdout = (
+                b"<Package tests>\n"
+                b"  <Module test_a.py>\n"
+                b"    <Function test_sample>\n"
+            )
+            mock_process.stderr = b""
+            mock_run.return_value = mock_process
+
+            # Create a pytest runner
+            runner = PytestRunner(set_python_path=True)
+
+            # Create a temporary directory for testing
+            test_dir = Path(BaseTest.TEST_DIR)
+            output_dir = test_dir / "events_python_test"
+
+            # Call runner.run with custom python interpreter
+            runner.run(
+                test_dir,
+                output_dir,
+                python=custom_python,
+            )
+
+            # Verify that subprocess.run was called
+            self.assertTrue(mock_run.called, "subprocess.run should have been called")
+
+            # Collect all the calls made to subprocess.run
+            calls = mock_run.call_args_list
+            self.assertGreater(
+                len(calls), 0, "Expected at least one call to subprocess.run"
+            )
+
+            # Check that the first call (pytest collection) uses the custom python interpreter
+            first_call_args = calls[0][0][0]  # Get the command list from the first call
+            self.assertIsInstance(first_call_args, list, "Command should be a list")
+            self.assertEqual(
+                first_call_args[0],
+                custom_python,
+                f"First subprocess call should start with {custom_python}, got {first_call_args[0]}",
+            )
+            self.assertIn(
+                "-m",
+                first_call_args,
+                "pytest collection call should contain -m argument",
+            )
+            self.assertIn(
+                "pytest",
+                first_call_args,
+                "pytest collection call should contain pytest argument",
+            )
+            self.assertIn(
+                "--collect-only",
+                first_call_args,
+                "pytest collection call should contain --collect-only argument",
+            )


### PR DESCRIPTION
This pull request introduces improvements to how the Python interpreter is handled within the test runner, as well as enhancements to parallel execution configuration and new test coverage. The most significant changes include allowing the Python interpreter to be explicitly passed throughout the codebase, updating default values for parallelism, and adding a unit test to verify interpreter selection.

**Python Interpreter Handling:**
* Updated the runner logic to consistently accept and pass a `python` argument, ensuring that subprocess calls (such as pytest collection) use the specified interpreter rather than defaulting to `python3`. [[1]](diffhunk://#diff-ed381ffaec298e6198f29c283a0372c5d5a30407ef3c8bdb14c9d19099b5fa84L106-R108) [[2]](diffhunk://#diff-ed381ffaec298e6198f29c283a0372c5d5a30407ef3c8bdb14c9d19099b5fa84L138-R147)

**Parallel Execution Configuration:**
* Introduced a `DEFAULT_MAX_WORKERS` constant (set to 64) and updated worker initialization logic to use this value instead of a hardcoded fallback, improving configurability and clarity for parallel test execution. [[1]](diffhunk://#diff-ed381ffaec298e6198f29c283a0372c5d5a30407ef3c8bdb14c9d19099b5fa84R28-R29) [[2]](diffhunk://#diff-ed381ffaec298e6198f29c283a0372c5d5a30407ef3c8bdb14c9d19099b5fa84L582-R591) [[3]](diffhunk://#diff-ed381ffaec298e6198f29c283a0372c5d5a30407ef3c8bdb14c9d19099b5fa84L648-R657)

**Testing Improvements:**
* Added a new test (`test_runner_python_interpreter`) that mocks subprocess calls to verify the correct Python interpreter is used during test collection, increasing confidence in interpreter selection logic.
* Cleaned up imports in the test file by removing unused modules and adding necessary mocks for the new test.

**Type Annotation Fix:**
* Corrected the return type annotation for the `use_parallel` static method to return a type rather than an instance, improving type safety and clarity.