### PR TITLE
Java/Defects4J backend update, compressed traces, and CONDITION_VALUE

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+resources/**/events/** binary
+*EVENTS_PATH binary

--- a/jsflkit/src/main/java/de/cispa/sflkitlib/JLib.java
+++ b/jsflkit/src/main/java/de/cispa/sflkitlib/JLib.java
@@ -3,9 +3,11 @@ package de.cispa.sflkitlib;
 import de.cispa.sflkitlib.events.JCodec;
 import de.cispa.sflkitlib.events.JPickle;
 
+import java.io.BufferedOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Collection;
 
 public class JLib {
@@ -13,7 +15,29 @@ public class JLib {
                                                         "EVENTS_PATH" : System.getenv(
             "EVENTS_PATH");
 
-    private static FileOutputStream EVENT_TRACE_FILE;
+    private static OutputStream EVENT_TRACE_FILE;
+
+    // Cap the number of events written per execution (EVENTS_MAX env var, 0 or
+    // unset = unlimited).  Loop-heavy code (e.g. numeric kernels) can emit tens
+    // of millions of events for a single test; once every feature has occurred,
+    // the extra repetitions only bloat the trace and slow the run (they even
+    // cause timeouts).  After the cap, events are dropped but the program runs
+    // on normally, so its pass/fail outcome is unchanged.
+    private static final long EVENTS_MAX = parseEventsMax();
+    private static volatile long eventCount = 0;
+
+    private static long parseEventsMax() {
+        String value = System.getenv("EVENTS_MAX");
+        if (value == null || value.trim().isEmpty()) {
+            return Long.MAX_VALUE;
+        }
+        try {
+            long parsed = Long.parseLong(value.trim());
+            return parsed <= 0 ? Long.MAX_VALUE : parsed;
+        } catch (NumberFormatException e) {
+            return Long.MAX_VALUE;
+        }
+    }
 
     // When EVENTS_THREADS is set, every event is prefixed with the id of the
     // writing thread (matching the Python codec's optional thread_id prefix), so
@@ -26,7 +50,8 @@ public class JLib {
 
     static {
         try {
-            EVENT_TRACE_FILE = new FileOutputStream(EVENT_TRACE_FILE_PATH);
+            EVENT_TRACE_FILE = new BufferedOutputStream(
+                    new FileOutputStream(EVENT_TRACE_FILE_PATH), 1 << 16);
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
@@ -49,7 +74,9 @@ public class JLib {
     public static void reset() {
         dump_events();
         try {
-            EVENT_TRACE_FILE = new FileOutputStream(EVENT_TRACE_FILE_PATH);
+            EVENT_TRACE_FILE = new BufferedOutputStream(
+                    new FileOutputStream(EVENT_TRACE_FILE_PATH), 1 << 16);
+            eventCount = 0;
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
@@ -64,8 +91,17 @@ public class JLib {
     }
 
     private static void write(byte[] encodedEvent) {
+        // Lock-free fast path once the cap is reached: loop-heavy code keeps
+        // calling this, so avoid acquiring the lock for every dropped event.
+        if (eventCount >= EVENTS_MAX) {
+            return;
+        }
         try {
             synchronized (LOCK) {
+                if (eventCount >= EVENTS_MAX) {
+                    return;
+                }
+                eventCount++;
                 if (THREAD_SUPPORT) {
                     EVENT_TRACE_FILE.write(
                             JCodec.encodeThreadId((int) Thread.currentThread().getId()));
@@ -104,6 +140,17 @@ public class JLib {
 
     public static void addConditionEvent(int eventID, boolean condition) {
         write(JCodec.encodeConditionEvent(eventID, condition));
+    }
+
+    /**
+     * Records a condition event inline and returns its value, so a loop test
+     * such as {@code while (cond)} can be instrumented as
+     * {@code while (evalCondition(id, (cond)))} without hoisting the condition
+     * into the body (which would break on {@code continue}/{@code break}).
+     */
+    public static boolean evalCondition(int eventID, boolean condition) {
+        write(JCodec.encodeConditionEvent(eventID, condition));
+        return condition;
     }
 
     public static void addLoopBeginEvent(int eventID) {
@@ -173,48 +220,48 @@ public class JLib {
         return 0;
     }
 
-    public static boolean hasLen(Collection<?> ignored) {
-        return true;
+    public static boolean hasLen(Collection<?> object) {
+        return object != null;
     }
 
-    public static boolean hasLen(Object[] ignored) {
-        return true;
+    public static boolean hasLen(Object[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(byte[] ignored) {
-        return true;
+    public static boolean hasLen(byte[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(short[] ignored) {
-        return true;
+    public static boolean hasLen(short[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(int[] ignored) {
-        return true;
+    public static boolean hasLen(int[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(long[] ignored) {
-        return true;
+    public static boolean hasLen(long[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(float[] ignored) {
-        return true;
+    public static boolean hasLen(float[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(double[] ignored) {
-        return true;
+    public static boolean hasLen(double[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(char[] ignored) {
-        return true;
+    public static boolean hasLen(char[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(boolean[] ignored) {
-        return true;
+    public static boolean hasLen(boolean[] object) {
+        return object != null;
     }
 
-    public static boolean hasLen(String ignored) {
-        return true;
+    public static boolean hasLen(String object) {
+        return object != null;
     }
 
     public static boolean hasLen(Object ignored) {

--- a/resources/subjects/tests/test_java_nulllen/NullLen.java
+++ b/resources/subjects/tests/test_java_nulllen/NullLen.java
@@ -1,0 +1,13 @@
+public class NullLen {
+    static int probe(String[] arr, String s) {
+        int n = -1;
+        if (arr != null) {
+            n = arr.length;
+        }
+        return n;
+    }
+
+    public static void main(String[] args) {
+        int r = probe(null, null);
+    }
+}

--- a/src/sflkit/analysis/factory.py
+++ b/src/sflkit/analysis/factory.py
@@ -309,9 +309,20 @@ class ScalarPairFactory(ComparisonFactory):
             if event.type_ in ["int", "float", "bool", "str", "bytes"]:
                 for types in (["int", "float", "bool"], ["str"], ["bytes"]):
                     if event.type_ in types:
+                        # Ordered comparison is meaningful between numbers
+                        # but not between two unrelated strings: `<` on str is
+                        # lexicographic, so pairs like
+                        # `unique < request_queue_size` assert nothing about the
+                        # program while crowding out real causes. Equality still
+                        # distinguishes states, so keep EQ/NE.
+                        comparators = self.comparators
+                        if types[0] in ("str", "bytes"):
+                            comparators = [
+                                c for c in comparators if c in (Comp.EQ, Comp.NE)
+                            ]
                         for variable in variables:
                             if variable.type_ in types:
-                                for comp in self.comparators:
+                                for comp in comparators:
                                     key = (
                                         ScalarPair.analysis_type(),
                                         event.file,

--- a/src/sflkit/events/event_file.py
+++ b/src/sflkit/events/event_file.py
@@ -1,9 +1,51 @@
+import io
 import os
 from pickle import PickleError
 
 from sflkitlib.events import event
 
 from sflkit.events.mapping import EventMapping
+
+GZIP_MAGIC = b"\x1f\x8b"
+ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+def open_event_stream(path: os.PathLike) -> io.BufferedReader:
+    """
+    Open an event file for reading, transparently decompressing it.
+
+    The runtime tracer may write the event stream through gzip or zstd, so the
+    codec is detected from the leading magic bytes rather than the file name.
+    The returned object always supports ``peek``, which the event reader relies
+    on to detect the end of the stream.
+
+    :param path: Path of the event file.
+    :returns: A buffered binary reader over the decoded event stream.
+    """
+    raw = open(path, "rb")
+    try:
+        header = raw.read(4)
+        raw.seek(0)
+    except OSError:
+        return raw
+
+    if header.startswith(GZIP_MAGIC):
+        import gzip
+
+        return io.BufferedReader(gzip.GzipFile(fileobj=raw, mode="rb"))
+    if header.startswith(ZSTD_MAGIC):
+        try:
+            import zstandard
+        except ImportError as e:
+            raw.close()
+            raise ImportError(
+                f"{path} is zstd-compressed but the 'zstandard' package is not "
+                "installed. Run: pip install zstandard"
+            ) from e
+        return io.BufferedReader(
+            zstandard.ZstdDecompressor().stream_reader(raw)
+        )
+    return raw
 
 
 class EventFile(object):
@@ -32,7 +74,7 @@ class EventFile(object):
         return self.run_id == other.run_id
 
     def __enter__(self):
-        self._file_pointer = open(self.path, "rb")
+        self._file_pointer = open_event_stream(self.path)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -45,14 +87,20 @@ class EventFile(object):
         return repr(self)
 
     def load(self):
-        while self._file_pointer.peek(1):
+        # A trace can end mid-stream: the run may have been killed by a timeout
+        # or have exhausted its trace budget. Every decoding error therefore
+        # ends the stream cleanly instead of failing the analysis; events read
+        # up to that point stay valid because events are written whole.
+        while True:
             try:
+                if not self._file_pointer.peek(1):
+                    break
                 e = event.load_next_event(
                     self._file_pointer,
                     self.mapping.mapping,
                     with_thread_id=self.thread_support,
                 )
-                if self.mapping.is_valid(e):
-                    yield e
-            except (IndexError, ValueError, PickleError, KeyError):
+            except (IndexError, ValueError, PickleError, KeyError, EOFError, OSError):
                 break
+            if self.mapping.is_valid(e):
+                yield e

--- a/src/sflkit/features/vector.py
+++ b/src/sflkit/features/vector.py
@@ -17,6 +17,18 @@ class FeatureVector:
         self.features: Dict[Feature, FeatureValue] = dict()
         self._lock = Lock()
 
+    def __getstate__(self) -> dict:
+        # Feature vectors are pickled as part of the FORECAST relevance tree.
+        # A ``threading.Lock`` is not picklable and holds no persistent state,
+        # so drop it here and recreate it on unpickling.
+        state = dict(self.__dict__)
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = Lock()
+
     def get_features_set(self) -> Set[Feature]:
         with self._lock:
             return set(self.features.keys())

--- a/src/sflkit/language/java/extract.py
+++ b/src/sflkit/language/java/extract.py
@@ -113,16 +113,22 @@ class JavaVarExtract(jast.JNodeVisitor, VariableExtract):
     def visit_Constant(self, node):
         return self.default_result()
 
+    @staticmethod
+    def _is_type_name(name) -> bool:
+        # By Java convention a type's first letter is uppercase (e.g. System,
+        # Integer).  Ignore leading '$'/'_' as used in generated or internal
+        # class names (e.g. Gson's `$Gson$Types`, `$Gson$Preconditions`).
+        return str(name).lstrip("$_")[:1].isupper()
+
     def visit_Name(self, node: jast.Name):
         if self.subscript:
             return self.default_result()
         name = str(node.id)
-        # Skip type/class references: by Java convention a bare identifier
-        # starting with an uppercase letter is a type (e.g. System, Integer),
-        # not a value, so it must not be passed to JLib.getID(...).  This also
-        # drops static accesses rooted at a type (e.g. System.out), which are
-        # not local data flow and would otherwise not compile.
-        if name[:1].isupper():
+        # Skip type/class references: a bare identifier that names a type is not
+        # a value, so it must not be passed to JLib.getID(...).  This also drops
+        # static accesses rooted at a type (e.g. System.out, $Gson$Types.x),
+        # which are not local data flow and would otherwise not compile.
+        if self._is_type_name(name):
             return self.default_result()
         return OrderedSet([name])
 
@@ -148,16 +154,36 @@ class JavaVarExtract(jast.JNodeVisitor, VariableExtract):
             return False
         return False
 
+    @staticmethod
+    def _dotted_name(node):
+        """Full dotted path of a pure ``Name(.Name)*`` chain, else ``None``."""
+        if isinstance(node, jast.Name):
+            return str(node.id)
+        if isinstance(node, jast.Member) and isinstance(node.member, jast.Name):
+            base = JavaVarExtract._dotted_name(node.value)
+            return None if base is None else f"{base}.{node.member.id}"
+        return None
+
     def visit_Member(self, node):
+        if not isinstance(node.member, jast.Name):
+            return self.visit(node.value)
+        # A segment that names a type (e.g. `pkg.Type`, `obj.Type.X`): the whole
+        # qualified reference names a type or a static member, not local data
+        # flow, so it must not be passed to JLib.getID(...).  Drop it (mirrors
+        # the rule in visit_Name).
+        if self._is_type_name(node.member.id):
+            return self.default_result()
         variables = self.visit(node.value)
-        if self.check_Member(node) and isinstance(node.member, jast.Name):
-            return (variables if self.use else {}) | OrderedSet(
-                f"{variable}.{node.member.id}"
-                for variable in variables
-                if variable not in self.current_ignores
-            )
-        else:
-            return variables
+        # Only extend the *full* name of the receiver (e.g. `a.b` -> `a.b.c`),
+        # and only when that receiver is itself a recognized value.  Extending
+        # every sub-prefix would fabricate names like `a.c` (or, for qualified
+        # names, mangle package segments such as `org.commons`).
+        if self.check_Member(node):
+            parent = self._dotted_name(node.value)
+            if parent is not None and parent in variables and parent not in self.current_ignores:
+                extended = OrderedSet([f"{parent}.{node.member.id}"])
+                return (variables | extended) if self.use else extended
+        return variables
 
     def visit_Call(self, node):
         return self.visit(node.args)
@@ -211,6 +237,26 @@ class JavaConditionExtract(jast.JNodeVisitor, ConditionExtract):
 
     def __assign_var(self, var, value):
         return jast.Expr(value=jast.Assign(target=jast.Name(id=var), value=value))
+
+    @staticmethod
+    def contains_assign(node):
+        # whether the expression assigns a variable (e.g. `(x = f()) == 0`)
+        if isinstance(node, jast.Assign):
+            return True
+        if isinstance(node, jast.JAST):
+            for _, value in node:
+                if isinstance(value, list):
+                    if any(
+                        JavaConditionExtract.contains_assign(item)
+                        for item in value
+                        if isinstance(item, jast.JAST)
+                    ):
+                        return True
+                elif isinstance(
+                    value, jast.JAST
+                ) and JavaConditionExtract.contains_assign(value):
+                    return True
+        return False
 
     def visit_BinOp(self, node):
         if not isinstance(node.op, (jast.And, jast.Or)):

--- a/src/sflkit/language/java/factory.py
+++ b/src/sflkit/language/java/factory.py
@@ -70,6 +70,77 @@ class JavaEventFactory(MetaVisitor, jast.JNodeVisitor, abc.ABC):
         super().__init__(
             language, event_id_generator, function_id_generator, tmp_generator
         )
+        # Stack of booleans: whether each enclosing class is a context in which
+        # static members (in particular static initializer blocks) may be
+        # declared.  A non-static member ("inner") class is not, so field
+        # instrumentation must avoid emitting static blocks there.
+        self._class_static_ctx = []
+        # Stack of the enclosing class nodes, to query the innermost kind.
+        self._class_stack = []
+
+    def enter_class(self, class_):
+        parent_static = self._class_static_ctx[-1] if self._class_static_ctx else True
+        is_top_level = not self._class_static_ctx
+        implicitly_static = isinstance(
+            class_, (jast.Interface, jast.Enum, jast.Record, jast.AnnotationDecl)
+        )
+        declared_static = any(
+            isinstance(mod, jast.Static) for mod in (getattr(class_, "modifiers", None) or [])
+        )
+        self._class_static_ctx.append(
+            is_top_level or implicitly_static or (declared_static and parent_static)
+        )
+        self._class_stack.append(class_)
+
+    def exit_class(self, class_):
+        if self._class_static_ctx:
+            self._class_static_ctx.pop()
+        if self._class_stack:
+            self._class_stack.pop()
+
+    def _can_declare_static(self) -> bool:
+        return self._class_static_ctx[-1] if self._class_static_ctx else True
+
+    def _in_interface(self) -> bool:
+        # Interfaces and annotation types allow no initializer blocks at all
+        # (their fields are implicit constants), so fields there cannot be
+        # instrumented with the pre/post/static blocks the factories emit.
+        return bool(self._class_stack) and isinstance(
+            self._class_stack[-1], (jast.Interface, jast.AnnotationDecl)
+        )
+
+    @staticmethod
+    def _can_complete_normally(stmt) -> bool:
+        # Conservative Java reachability check: can control fall through past
+        # ``stmt``?  Used to avoid placing an event after a body that always
+        # throws/returns/breaks (which would be an unreachable statement).
+        # Defaults to True for anything not recognized.
+        if stmt is None:
+            return True
+        if isinstance(stmt, (jast.Throw, jast.Return, jast.Break, jast.Continue)):
+            return False
+        if isinstance(stmt, (jast.Block, jast.Compound)):
+            body = stmt.body if isinstance(stmt.body, list) else [stmt.body]
+            return not body or JavaEventFactory._can_complete_normally(body[-1])
+        if isinstance(stmt, jast.If):
+            if stmt.orelse is None:
+                return True
+            return JavaEventFactory._can_complete_normally(
+                stmt.body
+            ) or JavaEventFactory._can_complete_normally(stmt.orelse)
+        return True
+
+    @classmethod
+    def _body_completes(cls, node) -> bool:
+        body = node.body
+        stmts = (
+            body.body
+            if isinstance(body, jast.Block)
+            else body
+            if isinstance(body, list)
+            else [body]
+        )
+        return not stmts or cls._can_complete_normally(stmts[-1])
 
     def visit_start(self, *args) -> Injection:
         # A visit_* method may fall through and return None (e.g. an assignment
@@ -109,11 +180,17 @@ class LineEventFactory(JavaEventFactory):
         return super().generic_visit(node)
 
     def visit_Field(self, node):
+        if self._in_interface():
+            return Injection()
         line_event = LineEvent(
             self.file, node.lineno, self.event_id_generator.get_next_id()
         )
         is_static = any(isinstance(mod, jast.Static) for mod in node.modifiers)
         if is_static:
+            if not self._can_declare_static():
+                # static field in a non-static inner class: a static initializer
+                # block would be an illegal static declaration, so skip it.
+                return Injection()
             return Injection(
                 static_pre_block=[self.get_event_call(line_event)], events=[line_event]
             )
@@ -165,11 +242,34 @@ class BranchEventFactory(JavaEventFactory):
             events=[then_branch_event, else_branch_event],
         )
 
+    @staticmethod
+    def _never_falls_through(node) -> bool:
+        # A loop a false condition can never exit: `while (true)`,
+        # `do {} while (true)`, `for (;;)` / `for (; true;)`.  Java treats the
+        # code after it as unreachable, so the exit-branch event must not be
+        # placed there.
+        test = getattr(node, "test", None)
+        if test is None:
+            return isinstance(node, jast.For)
+        return (
+            isinstance(test, jast.Constant)
+            and isinstance(test.value, jast.BoolLiteral)
+            and bool(test.value)
+        )
+
     def _visit_loop(self, node: jast.For | jast.ForEach | jast.While | jast.DoWhile):
         then_branch_event, else_branch_event = self._get_branch_events(node)
+        # Keep both branch ids registered (no gaps in the mapping), but do not
+        # emit the exit-branch call after a non-terminating loop; it would be
+        # unreachable and the branch is simply never taken.
+        post = (
+            []
+            if self._never_falls_through(node)
+            else [self.get_event_call(else_branch_event)]
+        )
         return Injection(
             body=[self.get_event_call(then_branch_event)],
-            post=[self.get_event_call(else_branch_event)],
+            post=post,
             events=[then_branch_event, else_branch_event],
         )
 
@@ -245,15 +345,23 @@ class DefEventFactory(JavaEventFactory):
         )
 
     def visit_LocalVariable(self, node: jast.LocalVariable):
-        def_events = []
-        for var in node.declarators:
-            def_events.append(self.get_event(node, var.id.id.value))
+        # only declarators with an initializer define a value; an uninitialized
+        # local (e.g. `int i;`) must not be read by a def event before assignment
+        def_events = [
+            self.get_event(node, var.id.id.value)
+            for var in node.declarators
+            if var.init is not None
+        ]
+        if not def_events:
+            return Injection()
         return Injection(
             post=[self.get_event_call(event) for event in def_events],
             events=def_events,
         )
 
     def visit_Field(self, node: jast.Field):
+        if self._in_interface():
+            return Injection()
         # Only fields with an initializer define a value at their declaration.
         # An uninitialized field (often final, assigned in a constructor) must
         # not be read by an initializer block before it is assigned.
@@ -266,6 +374,8 @@ class DefEventFactory(JavaEventFactory):
             return Injection()
         is_static = any(isinstance(mod, jast.Static) for mod in node.modifiers)
         if is_static:
+            if not self._can_declare_static():
+                return Injection()
             return Injection(
                 static_post_block=[self.get_event_call(event) for event in def_events],
                 events=def_events,
@@ -276,17 +386,16 @@ class DefEventFactory(JavaEventFactory):
         )
 
     def visit_For(self, node: jast.For):
+        # the loop is not desugared, so record the for-init definition inside the
+        # loop body where the variable is in scope (not after the loop)
         if node.init:
             if isinstance(node.init, jast.LocalVariable):
-                return self.visit_LocalVariable(node.init)
+                injection = self.visit_LocalVariable(node.init)
             else:
                 injection = Injection()
                 for var in node.init:
                     injection += self.visit(var)
-                return Injection(
-                    body=injection.post,
-                    events=injection.events,
-                )
+            return Injection(body=injection.post, events=injection.events)
         return Injection()
 
     def visit_ForEach(self, node: jast.ForEach):
@@ -418,8 +527,9 @@ class FunctionExitEventFactory(FunctionEventFactory):
     def visit_Method(self, node: jast.Method):
         if self._is_void(node.return_type):
             # void method: no return value to capture; only record exit on
-            # fall-through (explicit `return;` are handled by visit_Return).
-            if self.return_visitor.visit(node):
+            # fall-through (explicit `return;` are handled by visit_Return).  A
+            # body that always throws/returns has no reachable fall-through.
+            if self.return_visitor.visit(node) or not self._body_completes(node):
                 return Injection()
             function_exit_event = FunctionExitEvent(
                 self.file,
@@ -440,7 +550,7 @@ class FunctionExitEventFactory(FunctionEventFactory):
             value = jast.Constant(jast.IntLiteral(0))
         else:
             value = jast.Constant(jast.NullLiteral())
-        if not self.return_visitor.visit(node):
+        if not self.return_visitor.visit(node) and self._body_completes(node):
             function_exit_event = FunctionExitEvent(
                 self.file,
                 node.lineno,
@@ -622,20 +732,53 @@ class UseEventFactory(JavaEventFactory):
             self.file, node.lineno, self.event_id_generator.get_next_id(), var
         )
 
+    @staticmethod
+    def _embedded_assign_targets(node) -> set:
+        # Names assigned by an assignment nested inside an expression, e.g. `f`
+        # in `x = (f = g()) != null ? f : h()`.  Such a variable is not assigned
+        # before the statement, so a use of it must not be hoisted to `pre`.  We
+        # skip a statement-level assignment's own target (it is harmless, like
+        # the read in `x = x + 1`) and only scan the value side.
+        expr = node.value if isinstance(node, jast.Expr) else node
+        value = expr.value if isinstance(expr, jast.Assign) else expr
+        targets = set()
+        stack = [value]
+        while stack:
+            current = stack.pop()
+            if isinstance(current, jast.Assign):
+                if isinstance(current.target, jast.Name):
+                    targets.add(str(current.target.id))
+                stack.append(current.value)
+                continue
+            if isinstance(current, jast.JAST):
+                for _, child in current:
+                    if isinstance(child, list):
+                        stack.extend(c for c in child if isinstance(c, jast.JAST))
+                    elif isinstance(child, jast.JAST):
+                        stack.append(child)
+        return targets
+
     def visit_use(self, node: jast.stmt | jast.declaration):
         uses = self.use_extract.visit(node)
-        use_events = []
-        for use in uses:
-            use_events.append(self.get_event(node, use))
+        embedded = self._embedded_assign_targets(node)
+        use_events = [
+            self.get_event(node, use)
+            for use in uses
+            if use.split(".")[0] not in embedded
+        ]
         return Injection(
             pre=[self.get_event_call(event) for event in use_events],
             events=use_events,
         )
 
     def visit_Field(self, node):
+        if self._in_interface():
+            return Injection()
         injection = self.visit_use(node)
         is_static = any(isinstance(mod, jast.Static) for mod in node.modifiers)
         if is_static:
+            if not self._can_declare_static():
+                return Injection()
             return Injection(
                 static_pre_block=injection.pre,
                 events=injection.events,
@@ -645,46 +788,104 @@ class UseEventFactory(JavaEventFactory):
             events=injection.events,
         )
 
+    def _use_test(self, test):
+        # A test that assigns a variable (e.g. `(ch = str.charAt(i)) < 0x20`)
+        # cannot have its uses hoisted to before the statement: the assigned
+        # variable is not yet definitely assigned there.  Skip it, mirroring the
+        # condition factory's handling of such tests.
+        if test is None or self.condition_extract.contains_assign(test):
+            return Injection()
+        return self.visit_use(test)
+
     def visit_If(self, node: jast.If):
-        return self.visit_use(node.test)
+        return self._use_test(node.test)
 
     def visit_Switch(self, node: jast.Switch):
-        return self.visit_use(node.value)
+        return self._use_test(node.value)
+
+    @staticmethod
+    def _declared_names(node) -> set:
+        if isinstance(node, jast.LocalVariable):
+            return {str(declarator.id.id) for declarator in node.declarators}
+        return set()
+
+    @staticmethod
+    def _uninitialized_names(node) -> set:
+        # for-init variables declared without an initializer (e.g. `charCount`
+        # in `for (int charCount, i = 0; ...)`), which are not assigned at the
+        # start of the body.
+        if isinstance(node, jast.LocalVariable):
+            return {
+                str(declarator.id.id)
+                for declarator in node.declarators
+                if declarator.init is None
+            }
+        return set()
 
     def visit_For(self, node: jast.For):
         injection = Injection()
+        declared, uninitialized = set(), set()
         if node.init:
-            if isinstance(node.init, jast.LocalVariable):
-                injection += self.visit_use(node.init)
-            else:
-                for var in node.init:
-                    injection += self.visit_use(var)
-        update = Injection()
-        if node.update:
-            for var in node.update:
-                update += self.visit_use(var)
+            inits = (
+                [node.init] if isinstance(node.init, jast.LocalVariable) else node.init
+            )
+            for var in inits:
+                injection += self.visit_use(var)
+                declared |= self._declared_names(var)
+                uninitialized |= self._uninitialized_names(var)
         test = Injection()
         if node.test:
             test += self.visit_use(node.test)
+        # the loop is not desugared: init uses of *external* variables are in
+        # scope before the loop, but a use of a variable declared in the init
+        # itself (e.g. `for (int i = 0, end = i + 4; ...)`) is only in scope
+        # inside the body, alongside the test/update uses.  We do not append to
+        # the body end (body_last) because a body ending in a return/break would
+        # make them unreachable, and the native for handles the update itself.
+        init_pre, init_body = [], []
+        for call, event in zip(injection.pre, injection.events):
+            (init_body if event.var.split(".")[0] in declared else init_pre).append(call)
+        # The update runs at the body end, so its uses are placed at the body
+        # start as an approximation -- but a use of a for-init variable that has
+        # no initializer (assigned only in the body, e.g. `i += charCount`) is
+        # not yet definitely assigned there, so drop it.
+        update_pre, update_events = [], []
+        for var in node.update or []:
+            update = self.visit_use(var)
+            for call, event in zip(update.pre, update.events):
+                if event.var.split(".")[0] in uninitialized:
+                    continue
+                update_pre.append(call)
+                update_events.append(event)
         return Injection(
-            pre=injection.pre + test.pre,
-            body_last=update.pre + test.pre,
-            events=injection.events + test.events + update.events,
+            pre=init_pre,
+            body=init_body + test.pre + update_pre,
+            events=injection.events + test.events + update_events,
         )
 
     def visit_ForEach(self, node: jast.ForEach):
         return self.visit_use(node.iter)
 
     def visit_While(self, node: jast.While):
-        injection = self.visit_use(node.test)
+        # The while-condition variables are in scope before the loop, so record
+        # their uses there (once).  We do NOT also append them at the body end:
+        # a `continue` would skip that copy, and a body that always
+        # throws/returns/continues would make it an unreachable statement.
+        # `_use_test` also skips conditions that assign a variable (e.g.
+        # `while ((c = next()) != EOF)`), whose use cannot be hoisted before it.
+        injection = self._use_test(node.test)
         return Injection(
             pre=injection.pre,
-            body_last=injection.pre,
             events=injection.events,
         )
 
     def visit_DoWhile(self, node: jast.DoWhile):
-        injection = self.visit_use(node.test)
+        # A do-while evaluates its condition after the body, so the uses go at
+        # the body end -- but only when the body can fall through there (else
+        # they would be unreachable).
+        injection = self._use_test(node.test)
+        if not self._body_completes(node):
+            return Injection(events=injection.events)
         return Injection(
             body_last=injection.pre,
             events=injection.events,
@@ -732,7 +933,12 @@ class ConditionEventFactory(JavaEventFactory):
         return call
 
     def visit_condition(self, node: jast.If | jast.While | jast.DoWhile | jast.For):
-        if node.test:
+        # A test that assigns a later-used variable (e.g.
+        # `cs == null || (strLen = cs.length()) == 0`) cannot be hoisted into a
+        # tmp: the intermediate boolean hides the assignment from Java's
+        # definite-assignment analysis, so a later use of the variable fails to
+        # compile.  Leave such tests in place (no condition event recorded).
+        if node.test and not self.condition_extract.contains_assign(node.test):
             self.condition_extract.setup(self)
             var, var_use, var_assign, events = self.condition_extract.visit(node.test)
             return Injection(
@@ -742,77 +948,61 @@ class ConditionEventFactory(JavaEventFactory):
             )
         return Injection()
 
-    @staticmethod
-    def _to_reassignment(node):
-        """Turn tmp-var *declarations* in a condition setup into *assignments*.
+    def _inline_condition(self, node):
+        """Record a loop condition inline.
 
-        The condition tmp var is declared once before the loop (``pre``); inside
-        the loop body it must be re-assigned rather than re-declared, otherwise
-        the declaration shadows the outer one (a Java compile error).
+        Replaces ``cond`` with ``JLib.evalCondition(id, (cond))``, which logs the
+        condition event and returns the value.  Unlike hoisting the condition
+        into the loop body, this fires on every check (including after a
+        ``continue``), keeps the test in scope (the for-loop variable), and never
+        produces unreachable or definitely-unassigned code.  It records only the
+        loop's overall condition value, not decomposed ``&&``/``||`` operands.
         """
-        if isinstance(node, jast.Compound):
-            return jast.Compound(
-                body=[
-                    ConditionEventFactory._to_reassignment(s) for s in node.body
-                ]
-            )
-        if isinstance(node, jast.LocalVariable) and node.declarators[0].init is not None:
-            declarator = node.declarators[0]
-            return jast.Expr(
-                value=jast.Assign(
-                    target=jast.Name(id=declarator.id.id), value=declarator.init
-                )
-            )
-        return node
-
-    @staticmethod
-    def _bare_declarations(node):
-        """Bare ``boolean tmp;`` declarations for every tmp a condition setup
-        declares, so they can be hoisted before a do-while loop."""
-        decls = []
-        if isinstance(node, (jast.Compound, jast.Block)):
-            for stmt in node.body:
-                decls.extend(ConditionEventFactory._bare_declarations(stmt))
-        elif isinstance(node, jast.If):
-            decls.extend(ConditionEventFactory._bare_declarations(node.body))
-            if node.orelse is not None:
-                decls.extend(ConditionEventFactory._bare_declarations(node.orelse))
-        elif isinstance(node, jast.LocalVariable):
-            for declarator in node.declarators:
-                decls.append(
-                    jast.LocalVariable(
-                        type=jast.Boolean(),
-                        declarators=[
-                            jast.declarator(
-                                id=jast.variabledeclaratorid(id=declarator.id.id)
-                            )
-                        ],
-                    )
-                )
-        return decls
+        if node.test is None:
+            return Injection()
+        # A constant boolean condition matters to Java's reachability analysis:
+        # `while (true)` makes the code after the loop unreachable, so the
+        # enclosing method needs no trailing return.  Wrapping it in a call
+        # hides the constant and breaks that analysis, so leave it untouched
+        # (its value is constant and uninteresting anyway).
+        if isinstance(node.test, jast.Constant) and isinstance(
+            node.test.value, jast.BoolLiteral
+        ):
+            return Injection()
+        # A condition that assigns a variable used later (e.g.
+        # `for (int b; destOffs < hi && (b = read0()) >= 0; )`) must stay native:
+        # wrapping it in a call hides the assignment from Java's
+        # definite-assignment analysis (a method call does not propagate the
+        # "definitely assigned when true" flow), so the later use fails.
+        if self.condition_extract.contains_assign(node.test):
+            return Injection()
+        event = ConditionEvent(
+            self.file,
+            node.test.lineno,
+            self.event_id_generator.get_next_id(),
+            jast.unparse(node.test),
+            tmp_var=None,
+        )
+        call = jast.Member(
+            value=jast.Name(id=java_lib_name),
+            member=jast.Call(
+                func=jast.Name(id=jast.identifier("evalCondition")),
+                args=[jast.Constant(jast.IntLiteral(event.event_id)), node.test],
+            ),
+        )
+        return Injection(assign=call, events=[event])
 
     def visit_If(self, node: jast.If):
         return self.visit_condition(node)
 
     def visit_While(self, node: jast.While):
-        injection = self.visit_condition(node)
-        injection.body_last = [self._to_reassignment(s) for s in injection.pre]
-        return injection
+        return self._inline_condition(node)
 
     def visit_DoWhile(self, node: jast.DoWhile):
-        injection = self.visit_condition(node)
-        if injection.pre:
-            # do { ... } while (cond): the temp is used by the trailing `while`,
-            # so declare it before the loop and (re)assign it inside the body.
-            var_assign = injection.pre[0]
-            injection.pre = self._bare_declarations(var_assign)
-            injection.body_last = [self._to_reassignment(var_assign)]
-        return injection
+        return self._inline_condition(node)
 
     def visit_For(self, node: jast.For):
-        injection = self.visit_condition(node)
-        injection.body_last = [self._to_reassignment(s) for s in injection.pre]
-        return injection
+        return self._inline_condition(node)
 
 
 class LenEventFactory(DefEventFactory):
@@ -916,9 +1106,11 @@ class TestEventFactory(JavaEventFactory):
         self.functions -= 1
 
     def enter_class(self, class_):
+        super().enter_class(class_)
         self.classes += 1
 
     def exit_class(self, class_):
+        super().exit_class(class_)
         self.classes -= 1
 
     def visit(self, node):

--- a/src/sflkit/language/java/visitor.py
+++ b/src/sflkit/language/java/visitor.py
@@ -228,53 +228,11 @@ class JavaInstrumentation(jast.JNodeTransformer, ASTVisitor):
     def visit_If(self, node: jast.If) -> jast.JAST:
         return self.__visit_control(node)
 
-    @staticmethod
-    def __for_clause_stmts(clause):
-        """Normalize a for-loop init/update clause to a list of statements."""
-        if clause is None:
-            return []
-        items = clause if isinstance(clause, list) else [clause]
-        stmts = []
-        for item in items:
-            if isinstance(item, jast.stmt):
-                stmts.append(item)
-            else:
-                expr = jast.Expr(value=item)
-                expr.lineno = getattr(item, "lineno", None)
-                expr.end_lineno = getattr(item, "end_lineno", expr.lineno)
-                stmts.append(expr)
-        return stmts
-
     def visit_For(self, node: jast.For) -> jast.JAST:
-        # Desugar ``for (init; test; update) body`` into
-        # ``{ init; while (test) { body; update; } }`` so that variables declared
-        # in the for-init are in scope for every injected event (jast scopes them
-        # to the loop) and for-loops reuse the while-loop instrumentation path.
-        # NOTE: ``update`` runs at the end of the body, which differs from ``for``
-        # only under ``continue`` (a documented limitation).
-        init_stmts = self.__for_clause_stmts(node.init)
-        update_stmts = self.__for_clause_stmts(node.update)
-        if isinstance(node.body, jast.Block):
-            body_stmts = list(node.body.body)
-        elif node.body is not None:
-            body_stmts = [node.body]
-        else:
-            body_stmts = []
-        if node.test is not None:
-            test = node.test
-        else:
-            test = jast.Constant(jast.BoolLiteral(True))
-            test.lineno = node.lineno
-            test.end_lineno = node.end_lineno
-        while_node = jast.While(
-            test=test, body=jast.Block(body=body_stmts + update_stmts)
-        )
-        while_node.lineno = node.lineno
-        while_node.end_lineno = node.end_lineno
-        block = jast.Block(body=init_stmts + [while_node])
-        block.lineno = node.lineno
-        block.end_lineno = node.end_lineno
-        return self.visit(block)
+        # The for-loop is kept intact (no desugaring), so native continue/break,
+        # the update, and labels keep working.  The factories place the clause
+        # events inside the loop body (where the init variable is in scope).
+        return self.__visit_control(node)
 
     def visit_ForEach(self, node: jast.ForEach) -> jast.JAST:
         return self.__visit_control(node)
@@ -284,6 +242,48 @@ class JavaInstrumentation(jast.JNodeTransformer, ASTVisitor):
 
     def visit_DoWhile(self, node: jast.DoWhile) -> jast.JAST:
         return self.__visit_control(node)
+
+    _LOOPS = (jast.While, jast.DoWhile, jast.For, jast.ForEach)
+
+    @staticmethod
+    def __label_loop(label, stmt):
+        """Attach ``label`` to the loop inside a (possibly wrapped) statement.
+
+        Instrumenting a loop can wrap it in a Compound/Block (hoisted condition
+        setup, the for->while desugaring, etc.); the label must end up on the
+        actual loop so that ``continue``/``break`` with that label still resolve.
+        Returns the relabeled statement, or ``None`` if no loop was found.
+        """
+        if isinstance(stmt, JavaInstrumentation._LOOPS):
+            return jast.Labeled(label=label, body=stmt)
+        if isinstance(stmt, (jast.Compound, jast.Block)):
+            for index in range(len(stmt.body) - 1, -1, -1):
+                labeled = JavaInstrumentation.__label_loop(label, stmt.body[index])
+                if labeled is not None:
+                    stmt.body[index] = labeled
+                    return stmt
+        if isinstance(stmt, jast.Try):
+            # LOOP_END wraps the loop in a try/finally
+            labeled = JavaInstrumentation.__label_loop(label, stmt.body)
+            if labeled is not None:
+                stmt.body = labeled
+                return stmt
+        return None
+
+    def visit_Labeled(self, node: jast.Labeled) -> jast.JAST:
+        visited = self.visit(node.body)
+        labeled = self.__label_loop(node.label, visited)
+        if labeled is not None:
+            return labeled
+        # A labeled non-loop statement.  If instrumentation expanded it into a
+        # Compound (e.g. hoisted condition setup before a labeled `if`), wrap it
+        # in a real Block so the label encloses the whole thing; a Compound
+        # unparses inline, which would leave the label on only its first
+        # statement and break `break <label>` / `continue <label>` inside.
+        if isinstance(visited, jast.Compound):
+            visited = jast.Block(body=visited.body)
+        node.body = visited
+        return node
 
     def generic_visit(self, node: jast.JAST) -> jast.JAST:
         injection = self.meta_visitor.visit_start(node)

--- a/src/sflkit/language/language.py
+++ b/src/sflkit/language/language.py
@@ -29,6 +29,7 @@ _PYTHON_FACTORIES = {
     EventType.FUNCTION_EXIT: python_factory.FunctionExitEventFactor,
     EventType.FUNCTION_ERROR: python_factory.FunctionErrorEventFactory,
     EventType.CONDITION: python_factory.ConditionEventFactory,
+    EventType.CONDITION_VALUE: python_factory.ConditionValueEventFactory,
     EventType.LEN: python_factory.LenEventFactory,
     EventType.TEST_START: python_factory.TestStartEventFactory,
     EventType.TEST_END: python_factory.TestEndEventFactory,

--- a/src/sflkit/language/python/factory.py
+++ b/src/sflkit/language/python/factory.py
@@ -26,7 +26,12 @@ from sflkitlib.events.event import (
 
 from sflkit.language.meta import MetaVisitor, Injection, IDGenerator, TmpGenerator
 
-python_lib = "sflkitlib.lib"
+python_lib_module = "sflkitlib.lib"
+# Dunder-shaped so namespace-cleanup idioms that keep only dunders and own
+# submodules (astropy/__init__.py) do not delete the tracer binding; a plain
+# name is deleted and the next probe raises NameError, killing the import.
+# Also one attribute lookup fewer per probe.
+python_lib = "__sflkitlib__"
 
 
 def get_call(function, *args) -> Expr:
@@ -772,19 +777,13 @@ class UseEventFactory(PythonEventFactory):
             body=[self._get_wrapped_property(event)],
             handlers=[
                 ExceptHandler(
-                    type=Tuple(
-                        elts=[
-                            Name(
-                                id="AttributeError",
-                            ),
-                            Name(
-                                id="TypeError",
-                            ),
-                            Name(
-                                id="NameError",
-                            ),
-                        ],
-                    ),
+                    # Any exception: evaluating a probe's own arguments runs
+                    # subject code (len() on a lazy proxy, attribute access via
+                    # __getattribute__) which can raise anything. Django's
+                    # settings raise ImproperlyConfigured when touched before
+                    # configuration, and a narrow guard let that abort the
+                    # import of the package under test.
+                    type=Name(id="Exception"),
                     name=None,
                     body=[Pass()],
                 ),
@@ -810,11 +809,28 @@ class UseEventFactory(PythonEventFactory):
         )
         return call
 
+    @staticmethod
+    def _get_type_of(class_: str) -> Call:
+        """
+        Build ``type(<class_>)``.
+
+        Deliberately ``type(x)`` and not ``x.__class__``: the two agree for
+        ordinary objects, but ``__class__`` is a normal attribute lookup and can
+        itself be a property. Django's lazy objects define
+        ``__class__ = property(new_method_proxy(...))``, so reading it re-enters
+        the proxy machinery this guard is meant to stay out of, recursing until
+        the stack is exhausted. ``type()`` reads the type slot directly and
+        cannot be proxied -- django's own source makes the same point: "We have
+        to use type(self), not self.__class__, because the latter is proxied."
+        """
+        return Call(func=Name(id="type"), args=[Name(id=class_)], keywords=[])
+
     def _get_wrapped_property(self, event: UseEvent):
         body = self._get_std_call(event)
         attributes = event.var.split(".")
         for i in range(len(attributes) - 1):
             class_ = ".".join(attributes[: -1 - i])
+            attribute = attributes[-1 - i]
             body = If(
                 test=BoolOp(
                     op=Or(),
@@ -826,9 +842,9 @@ class UseEventFactory(PythonEventFactory):
                                     id="hasattr",
                                 ),
                                 args=[
-                                    Name(id=class_ + ".__class__"),
+                                    self._get_type_of(class_),
                                     Constant(
-                                        value=attributes[-1 - i],
+                                        value=attribute,
                                     ),
                                 ],
                                 keywords=[],
@@ -841,8 +857,10 @@ class UseEventFactory(PythonEventFactory):
                                     id="isinstance",
                                 ),
                                 args=[
-                                    Name(
-                                        id=class_ + ".__class__." + attributes[-1 - i]
+                                    Attribute(
+                                        value=self._get_type_of(class_),
+                                        attr=attribute,
+                                        ctx=Load(),
                                     ),
                                     Name(
                                         id="property",
@@ -1009,19 +1027,13 @@ class LenEventFactory(DefEventFactory):
             body=[call],
             handlers=[
                 ExceptHandler(
-                    type=Tuple(
-                        elts=[
-                            Name(
-                                id="AttributeError",
-                            ),
-                            Name(
-                                id="TypeError",
-                            ),
-                            Name(
-                                id="NameError",
-                            ),
-                        ],
-                    ),
+                    # Any exception: evaluating a probe's own arguments runs
+                    # subject code (len() on a lazy proxy, attribute access via
+                    # __getattribute__) which can raise anything. Django's
+                    # settings raise ImproperlyConfigured when touched before
+                    # configuration, and a narrow guard let that abort the
+                    # import of the package under test.
+                    type=Name(id="Exception"),
                     name=None,
                     body=[Pass()],
                 )

--- a/src/sflkit/language/python/factory.py
+++ b/src/sflkit/language/python/factory.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import typing
 from ast import *
 
@@ -15,6 +16,7 @@ from sflkitlib.events.event import (
     LoopEndEvent,
     UseEvent,
     ConditionEvent,
+    ConditionValueEvent,
     LenEvent,
     TestStartEvent,
     TestEndEvent,
@@ -995,6 +997,89 @@ class ConditionEventFactory(PythonEventFactory):
 
     def visit_If(self, node: If) -> Injection:
         return self.visit_condition(node)
+
+
+class ConditionValueEventFactory(PythonEventFactory):
+    """Emit a branch-distance companion event for single-comparison conditions.
+
+    For an ``if``/``while`` whose test is a lone comparison ``lhs <op> rhs`` with
+    side-effect-free operands, inject a call that reports the operands to the
+    runtime, which computes the branch distance. The original test is left
+    untouched (the plain :class:`ConditionEventFactory` still records its
+    boolean), so this is purely additive; compound tests, non-comparison tests,
+    and tests with side-effecting operands are skipped and fall back to the
+    boolean condition event plus approach-level guidance.
+    """
+
+    _OPS = {
+        ast.Lt: "<",
+        ast.LtE: "<=",
+        ast.Gt: ">",
+        ast.GtE: ">=",
+        ast.Eq: "==",
+        ast.NotEq: "!=",
+    }
+
+    def get_function(self):
+        return "add_condition_value_event"
+
+    @staticmethod
+    def _is_pure(node: AST) -> bool:
+        # Operands we can safely re-evaluate: no calls, subscripts, or operators
+        # that could have side effects.
+        if isinstance(node, Constant):
+            return True
+        if isinstance(node, Name):
+            return True
+        if isinstance(node, Attribute):
+            return ConditionValueEventFactory._is_pure(node.value)
+        if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):
+            return ConditionValueEventFactory._is_pure(node.operand)
+        return False
+
+    def _capturable(self, test: AST):
+        if not isinstance(test, Compare) or len(test.ops) != 1:
+            return None
+        op = self._OPS.get(type(test.ops[0]))
+        if op is None:
+            return None
+        lhs, rhs = test.left, test.comparators[0]
+        if not (self._is_pure(lhs) and self._is_pure(rhs)):
+            return None
+        return op, lhs, rhs
+
+    def _get_event_call(self, event: ConditionValueEvent, op: str, lhs, rhs):
+        # sflkitlib.lib.add_condition_value_event(event_id, lhs, rhs, "op")
+        call = get_call(self.get_function(), event.event_id)
+        assert isinstance(call.value, Call)
+        call.value.args.append(copy.deepcopy(lhs))
+        call.value.args.append(copy.deepcopy(rhs))
+        call.value.args.append(Constant(value=op))
+        return call
+
+    def visit_condition(self, node: typing.Union[If, While]) -> Injection:
+        capturable = self._capturable(node.test)
+        if capturable is None:
+            return Injection()
+        op, lhs, rhs = capturable
+        event = ConditionValueEvent(
+            self.file,
+            node.lineno,
+            self.event_id_generator.get_next_id(),
+            ast.unparse(node.test),
+            op,
+        )
+        return Injection(
+            pre=[self._get_event_call(event, op, lhs, rhs)], events=[event]
+        )
+
+    def visit_If(self, node: If) -> Injection:
+        return self.visit_condition(node)
+
+    def visit_While(self, node: While) -> Injection:
+        injection = self.visit_condition(node)
+        injection.body_last = injection.pre
+        return injection
 
 
 class LenEventFactory(DefEventFactory):

--- a/src/sflkit/language/python/visitor.py
+++ b/src/sflkit/language/python/visitor.py
@@ -3,7 +3,7 @@ from typing import Any, Union
 
 from sflkit.language.meta import MetaVisitor, Injection
 from sflkit.language.python.extract import PythonIsDoc
-from sflkit.language.python.factory import python_lib
+from sflkit.language.python.factory import python_lib, python_lib_module
 from sflkit.language.visitor import ASTVisitor
 
 
@@ -28,7 +28,7 @@ class PythonInstrumentation(NodeTransformer, ASTVisitor):
             body=doc
             + self.__future__
             + [
-                Import(names=[alias(name=python_lib, asname=None)]),
+                Import(names=[alias(name=python_lib_module, asname=python_lib)]),
                 instrumented_tree,
             ],
             type_ignores=list(),

--- a/src/sflkit/model/model.py
+++ b/src/sflkit/model/model.py
@@ -14,6 +14,7 @@ from sflkitlib.events.event import (
     FunctionExitEvent,
     FunctionErrorEvent,
     ConditionEvent,
+    ConditionValueEvent,
     LoopBeginEvent,
     LoopHitEvent,
     LoopEndEvent,
@@ -97,6 +98,14 @@ class Model:
         self.handle_event(event, event_file, self.variables[event_file])
 
     def handle_condition_event(self, event: ConditionEvent, event_file: EventFile):
+        self.handle_event(event, event_file)
+
+    def handle_condition_value_event(
+        self, event: ConditionValueEvent, event_file: EventFile
+    ):
+        # Additive companion event: no analysis subscribes to CONDITION_VALUE, so
+        # this is a no-op for spectra/predicates. GIFT reads the branch distance
+        # straight from the decoded event stream.
         self.handle_event(event, event_file)
 
     def handle_loop_begin_event(self, event: LoopBeginEvent, event_file: EventFile):

--- a/src/sflkit/runners/defects4j.py
+++ b/src/sflkit/runners/defects4j.py
@@ -37,7 +37,9 @@ DEFAULT_EVENTS = [
     EventType.LOOP_HIT,
 ]
 
-_JAVAC_ERROR = re.compile(r"^(?P<file>/[^:\n]+\.java):\d+: error:", re.MULTILINE)
+_JAVAC_ERROR = re.compile(
+    r"^(?P<file>/[^:\n]+\.java):\d+: error: (?P<msg>.*)$", re.MULTILINE
+)
 _RESOURCE = Path(__file__).parent / "resources" / "SflkitTestRunner.java"
 
 
@@ -58,6 +60,13 @@ class Defects4J:
         self.bin = self.home / "framework" / "bin" / "defects4j"
         if not self.bin.exists():
             raise Defects4JError(f"defects4j not found at {self.bin}")
+        # Defects4J bundles a JUnit 4 jar (which also contains the JUnit 3
+        # ``junit.framework.*`` classes).  Our test launcher uses the JUnit 4
+        # API, but some subjects (e.g. Cli) put only JUnit 3.8.1 on cp.test, so
+        # we prepend this jar to the launcher's classpath.
+        self.junit_jar = (
+            self.home / "framework" / "projects" / "lib" / "junit-4.12-hamcrest-1.3.jar"
+        )
         # Recent Defects4J requires Java 11; allow overriding via env.
         java = (
             java_home
@@ -167,12 +176,16 @@ class Defects4JRunner(Runner):
         timeout: int = 300,
         max_compile_retries: int = 50,
         thread_support: bool = False,
+        events_max: int = 500_000,
     ):
         super().__init__(timeout=timeout, thread_support=thread_support)
         self.jlib_jar = str(jlib_jar)
         self.defects4j = defects4j or Defects4J()
         self.events = events or list(DEFAULT_EVENTS)
         self.max_compile_retries = max_compile_retries
+        # Cap events written per test so loop-heavy code does not produce
+        # multi-hundred-MB traces (or time out); 0 disables the cap.
+        self.events_max = events_max
         # populated by setup()
         self.workdir: Optional[Path] = None
         self.run_classpath: Optional[str] = None
@@ -196,12 +209,21 @@ class Defects4JRunner(Runner):
         d4j = self.defects4j
         LOGGER.info(f"Checking out {project}-{bug}b into {workdir}")
         d4j.checkout(project, bug, workdir)
-        d4j.compile(workdir)
 
+        # Export every defects4j property BEFORE compiling.  For some subjects
+        # (e.g. Mockito) a `defects4j export` triggers a production-only rebuild
+        # that wipes the already-compiled test classes, so `compile` must be the
+        # last defects4j build action before we run tests.
         src_classes = workdir / d4j.export("dir.src.classes", workdir)
         cp_compile = d4j.export("cp.compile", workdir)
         cp_test = d4j.export("cp.test", workdir)
         bin_classes = workdir / d4j.export("dir.bin.classes", workdir)
+        trigger_raw = relevant_raw = None
+        if tests is None:
+            trigger_raw = d4j.export("tests.trigger", workdir)
+            relevant_raw = d4j.export("tests.relevant", workdir)
+
+        d4j.compile(workdir)
 
         # instrument source classes (with per-file fallback)
         instrumented_src = workdir / ".sflkit_instrumented_src"
@@ -215,17 +237,22 @@ class Defects4JRunner(Runner):
         # file whose instrumentation does not compile
         self._recompile(instrumented_src, src_classes, bin_classes, cp_compile)
 
-        # compile the JUnit launcher against the test classpath
+        # compile the JUnit launcher against the test classpath, with the
+        # bundled JUnit 4 jar prepended so its API resolves even on subjects
+        # that only put JUnit 3 on cp.test
         runner_dir = workdir / ".sflkit_runner"
         runner_dir.mkdir(exist_ok=True)
-        self._compile_runner(cp_test, runner_dir)
+        junit_cp_test = os.pathsep.join([str(self.defects4j.junit_jar), cp_test])
+        self._compile_runner(junit_cp_test, runner_dir)
 
         self.workdir = workdir
         self.mapping_path = mapping_path
-        self.run_classpath = os.pathsep.join([cp_test, str(runner_dir), self.jlib_jar])
+        self.run_classpath = os.pathsep.join(
+            [str(self.defects4j.junit_jar), cp_test, str(runner_dir), self.jlib_jar]
+        )
 
         if tests is None:
-            tests = self._collect_tests(project, workdir)
+            tests = self._collect_tests(trigger_raw, relevant_raw)
         LOGGER.info(f"Running {len(tests)} tests for {project}-{bug}b")
         self.run_tests(workdir, output, tests)
         return self.tests
@@ -235,12 +262,31 @@ class Defects4JRunner(Runner):
     def _recompile(self, instrumented_src, original_src, out_dir, cp_compile):
         sources = self._java_files(instrumented_src)
         reverted_total = 0
+        # Some subjects (e.g. Mockito) compile production code against
+        # JUnit/Hamcrest that defects4j does not put on cp.compile, and ship two
+        # Hamcrest versions.  Append the bundled JUnit so org.junit resolves, and
+        # move any hamcrest-core jar to the front so the older Hamcrest wins
+        # (Mockito's production matchers target Hamcrest 1.1, not 1.3).  Both are
+        # no-ops for subjects that do not reference these from production code.
+        entries = cp_compile.split(os.pathsep)
+        hamcrest_core = [e for e in entries if "hamcrest-core" in e]
+        compile_cp = os.pathsep.join(
+            hamcrest_core + entries + [self.jlib_jar, str(self.defects4j.junit_jar)]
+        )
+        # Default to modern UTF-8.  If the default trips on a toolchain mismatch
+        # -- a non-UTF-8 source file ("unmappable character"), or pre-Java-8
+        # generics inference that newer javac rejects ("bad type in conditional
+        # expression") -- switch to the old-project profile (ISO-8859-1 is
+        # byte-preserving and source 7 restores the lenient inference) and retry
+        # before reverting; these are not instrumentation failures.
+        compile_flags = ["-encoding", "UTF-8"]
+        switched = False
         for _ in range(self.max_compile_retries):
             result = subprocess.run(
                 [
                     self.defects4j.javac,
-                    "-encoding", "UTF-8", "-nowarn",
-                    "-cp", os.pathsep.join([cp_compile, self.jlib_jar]),
+                    *compile_flags, "-nowarn",
+                    "-cp", compile_cp,
                     "-d", str(out_dir),
                     *sources,
                 ],
@@ -255,9 +301,28 @@ class Defects4JRunner(Runner):
                         f"did not compile"
                     )
                 return
-            bad_files = set(_JAVAC_ERROR.findall(result.stderr))
+            if not switched and (
+                "unmappable character" in result.stderr
+                or "bad type in conditional expression" in result.stderr
+            ):
+                compile_flags = ["-encoding", "ISO-8859-1", "-source", "7", "-target", "7"]
+                switched = True
+                continue
+            errors_by_file: Dict[str, List[str]] = {}
+            for bad, msg in _JAVAC_ERROR.findall(result.stderr):
+                errors_by_file.setdefault(bad, []).append(msg)
+            # Revert only the root-cause files first.  "cannot find symbol" is
+            # usually a cascade from a dependency that failed to compile, so
+            # reverting those would needlessly de-instrument healthy files; once
+            # the real culprit is reverted, the cascade errors disappear.
+            root = [
+                bad
+                for bad, msgs in errors_by_file.items()
+                if any(not m.startswith("cannot find symbol") for m in msgs)
+            ]
+            targets = root or list(errors_by_file)
             reverted = False
-            for bad in bad_files:
+            for bad in targets:
                 relative = os.path.relpath(bad, instrumented_src)
                 original = os.path.join(original_src, relative)
                 if os.path.exists(original) and not _same_file(bad, original):
@@ -280,15 +345,15 @@ class Defects4JRunner(Runner):
         if result.returncode:
             raise Defects4JError(f"Could not compile test runner:\n{result.stderr}")
 
-    def _collect_tests(self, project, workdir) -> List[str]:
-        trigger = [
-            t for t in self.defects4j.export("tests.trigger", workdir).splitlines() if t
-        ]
-        relevant_classes = [
-            c
-            for c in self.defects4j.export("tests.relevant", workdir).splitlines()
-            if c
-        ]
+    def _collect_tests(self, trigger_raw: str, relevant_raw: str) -> List[str]:
+        # ``trigger_raw``/``relevant_raw`` are exported before compiling (see
+        # collect): re-exporting here would rebuild and wipe the test classes.
+        # Defects4J reports triggers as ``Class::method`` but SflkitTestRunner
+        # (and the listed methods below) use ``Class#method``; normalize so the
+        # trigger actually runs and dedups against the listed methods instead of
+        # mis-parsing into a bogus, traceless failure.
+        trigger = [t.replace("::", "#") for t in trigger_raw.splitlines() if t]
+        relevant_classes = [c for c in relevant_raw.splitlines() if c]
         methods: List[str] = list(trigger)
         seen = set(trigger)
         for test_class in relevant_classes:
@@ -311,7 +376,10 @@ class Defects4JRunner(Runner):
     # ----- Runner interface ----------------------------------------------
 
     def get_tests(self, directory, files=None, base=None, environ=None, python=None, k=None):
-        return self._collect_tests(None, directory)
+        return self._collect_tests(
+            self.defects4j.export("tests.trigger", directory),
+            self.defects4j.export("tests.relevant", directory),
+        )
 
     def run_test(self, directory, test, environ=None, python=None) -> TestResult:
         environ = dict(environ or self.defects4j.env)
@@ -319,6 +387,13 @@ class Defects4JRunner(Runner):
         environ.pop("EVENTS_PATH", None)
         # JLib prefixes every event with its thread id when this is set.
         environ["EVENTS_THREADS"] = "1" if self.thread_support else "0"
+        # Bound the per-test trace so loop-heavy code cannot blow up the trace
+        # size or run time (0 = unlimited).
+        environ["EVENTS_MAX"] = str(self.events_max)
+        # Defects4J pins the timezone to America/Los_Angeles so that defects
+        # reproduce regardless of the host timezone (framework Constants.pm).
+        # Without this, timezone-sensitive tests are misclassified.
+        environ["TZ"] = "America/Los_Angeles"
         try:
             result = subprocess.run(
                 [self.defects4j.java, "-cp", self.run_classpath, "SflkitTestRunner",

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -402,9 +402,11 @@ class JavaEndToEndTest(unittest.TestCase):
         self.assertEqual(4, sum(isinstance(e, LoopHitEvent) for e in events))
 
     def test_for_loop_decode(self):
-        # `for (int i = 0; i < n; ...)` is desugared into a while loop so that
-        # the loop variable is in scope for the injected def/use/condition
-        # events; sum(4) iterates four times and tests its condition five times.
+        # the for-loop is kept native (not desugared); its def/use events are
+        # recorded in the body where the loop variable is in scope, so sum(4)
+        # iterates four times and i is defined and used.  Its condition `i < n`
+        # is recorded inline (no body hoisting), so it fires on every check:
+        # four times true and once false.
         events = self._run(
             "test_java_for",
             "ForLoop",
@@ -420,8 +422,36 @@ class JavaEndToEndTest(unittest.TestCase):
             ],
         )
         self.assertEqual(4, sum(isinstance(e, LoopHitEvent) for e in events))
-        self.assertEqual(5, sum(isinstance(e, ConditionEvent) for e in events))
         self.assertTrue(any(isinstance(e, DefEvent) and e.var == "i" for e in events))
+        self.assertTrue(any(isinstance(e, UseEvent) and e.var == "i" for e in events))
+        conditions = [e.value for e in events if isinstance(e, ConditionEvent)]
+        self.assertEqual([True, True, True, True, False], conditions)
+
+    def test_null_length_does_not_alter_behavior(self):
+        # A null array/String reaching a LEN event must not crash: hasLen(null)
+        # is false, so getLen(null) is never called.  Were it otherwise, the
+        # NullPointerException would abort the method and silently change the
+        # program's behavior (a real instrumentation bug found on Lang-10).
+        events = self._run(
+            "test_java_nulllen",
+            "NullLen",
+            [
+                EventType.LINE,
+                EventType.DEF,
+                EventType.FUNCTION_ENTER,
+                EventType.FUNCTION_EXIT,
+                EventType.LEN,
+            ],
+        )
+        # the null parameters are defined ...
+        self.assertTrue(any(isinstance(e, DefEvent) and e.var == "arr" for e in events))
+        # ... but no length event is emitted for the null ones ...
+        self.assertFalse(
+            any(isinstance(e, LenEvent) and e.var in {"arr", "s"} for e in events)
+        )
+        # ... and probe() still returns normally (-1), i.e. it was not aborted.
+        exits = {(e.function, e.return_value) for e in events if isinstance(e, FunctionExitEvent)}
+        self.assertIn(("probe", -1), exits)
 
     def test_all_event_types_decode(self):
         events = self._run(


### PR DESCRIPTION
Brings together four lines of work that had drifted apart across branches and a local repository that was never connected to GitHub.

## What lands here

- **Java/Defects4J backend, newest revision.** The backend on `dev` dates from June. It was developed further locally: revert hardening across 13 Defects4J projects, the null-length behavior-preservation fix in `JLib`, the per-run event cap and buffering, and the Defects4J runner's timezone and classpath handling.
- **Compressed and truncated trace reading.** gzip/zstd detected from magic bytes, and a trace that ends mid-stream (timeout, exhausted trace budget) now ends cleanly instead of failing the analysis.
- **Instrumentation hardening.** Probes no longer perturb the program under test: any exception from evaluating a probe's own arguments is swallowed, `type(x)` replaces `x.__class__` so lazy proxies cannot recurse, and the runtime binds through a dunder-shaped name that namespace-cleanup idioms do not delete.
- **`CONDITION_VALUE`.** Factory mapping so configs can request it, plus `Model.handle_condition_value_event`.

## One real bug fixed

`sflkitlib` dispatches events to the model by method name, so `Model` needed `handle_condition_value_event`. Without it, decoding any trace containing a `CONDITION_VALUE` event raised `AttributeError` even with the factory mapping in place.

## How it was assembled

`dev` and `forecast-instrumentation-fixes` both fork from b299fa5, so this is a clean 3-way merge, not a graft. The Java files then come from the local lineage (preserved as tag `archive/conditionvalue-wip`), which is roughly a month newer than every Java commit on `dev`.

Left out on purpose, since that lineage was a working-tree snapshot rather than curated commits: `3783989.pdf`, `coverage.json`, and its `.gitignore` entry for the nested `sflkit-lib/` checkout.

## Tests

282 passed, matching the count from before the repository was reconnected. The 24 Java tests and `test_defects4j.py` are back.