### PR TITLE
0.6.0: collect analysis artifacts during execution, and make the analysis fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ whether individual lines are part of the execution.
 
 ## Language Support
 
-SFLKit supports currently Python 3 but we plan on releasing further language support.
+SFLKit supports Python 3.
+
+Events are collected either by instrumenting the sources, or without instrumenting
+anything at all, by tracing the program as it runs; see `sflkit.online`. Both
+produce the same events, so every spectrum, predicate and metric applies either way.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Testing"
 ]
 dependencies = [
-    "sflkitlib>=0.2.2",
+    "sflkitlib>=0.2.4",
     "numpy>=2.1.3",
     "matplotlib>=3.10.0",
     "pandas>=2.2.3",

--- a/src/sflkit/__init__.py
+++ b/src/sflkit/__init__.py
@@ -5,7 +5,7 @@ from sflkit.analysis.analyzer import Analyzer
 from sflkit.config import Config, parse_config
 from sflkit.instrumentation.dir_instrumentation import DirInstrumentation
 
-__version__ = "0.5.7"
+__version__ = "0.6.0"
 
 
 def instrument_config(conf: Config):

--- a/src/sflkit/analysis/analyzer.py
+++ b/src/sflkit/analysis/analyzer.py
@@ -1,6 +1,6 @@
 import json
 import os
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from typing import List, Callable, Set, Dict, Optional, Any, Type
 
 from sflkit.analysis.analysis_type import AnalysisType, AnalysisObject
@@ -26,6 +26,58 @@ from sflkit.model.model import Model, MetaModel
 from sflkit.model.parallel import ParallelModel
 
 
+def analyze_files(
+    factory: AnalysisFactory, event_files: List[EventFile]
+) -> Set[AnalysisObject]:
+    """
+    Analyze a share of the runs, start to finish, in one process.
+
+    Defined at module level so it can be shipped to a worker process, and kept
+    free of shared state so that workers never have to talk to each other: the
+    runs are partitioned, so the per-run state each worker accumulates is
+    disjoint from every other worker's and merges by simple union.
+
+    Suspiciousness is deliberately *not* computed here. It is a property of the
+    whole suite, so it can only be derived once every worker's share has been
+    merged.
+
+    :param factory: A fresh analysis factory.
+    :param event_files: The runs this worker is responsible for.
+    :returns: The analysis objects it built.
+    """
+    model = Model(factory)
+    for event_file in event_files:
+        model.prepare(event_file)
+        with event_file:
+            for event in event_file.load():
+                event.handle(model, event_file)
+        model.follow_up(event_file)
+    return model.get_analysis()
+
+
+def merge_analysis(target: AnalysisObject, source: AnalysisObject) -> None:
+    """
+    Fold a worker's view of one analysis object into the parent's.
+
+    Everything an object accumulates while events are handled is keyed by run,
+    and workers hold disjoint runs, so merging is a dictionary update. Which
+    attributes those are is discovered rather than hard-coded, so a subclass
+    that adds per-run state of its own is merged too instead of silently
+    losing it.
+
+    :param target: The object the parent keeps.
+    :param source: The equal object a worker produced.
+    """
+    for name, value in vars(source).items():
+        if not isinstance(value, dict) or not value:
+            continue
+        if not all(isinstance(key, EventFile) for key in value):
+            continue
+        current = getattr(target, name, None)
+        if isinstance(current, dict):
+            current.update(value)
+
+
 class AnalysisEncoder(json.JSONEncoder):
     def default(self, o: Any) -> Any:
         if isinstance(o, AnalysisObject):
@@ -44,6 +96,7 @@ class Analyzer:
         model_class: Type[Model] = None,
         parallel: bool = False,
         workers: int = 4,
+        processes: int = 1,
     ):
         if (
             relevant_event_files is None
@@ -67,6 +120,10 @@ class Analyzer:
                     model_class = Model
             self.model = model_class(factory)
         self.workers = workers
+        #: Worker processes to spread the runs over. Threads cannot help here:
+        #: analysis is Python-level work and the GIL serializes it, while runs
+        #: are independent until suspiciousness is computed.
+        self.processes = processes
         self.paths: Dict[int, os.PathLike] = dict()
         self.max_suspiciousness = 0
         self.min_suspiciousness = 0
@@ -87,9 +144,49 @@ class Analyzer:
             raise NotImplementedError("Not implemented for meta/loaded analyzer")
         self.model.finalize(self.irrelevant_event_files, self.relevant_event_files)
 
+    def _analyze_with_processes(self, event_files: List[EventFile]):
+        """
+        Analyze *event_files* across worker processes and merge the results.
+
+        :param event_files: Every run to analyze.
+
+        Uses :class:`~concurrent.futures.ProcessPoolExecutor`, so on platforms
+        that start workers with ``spawn`` (macOS, Windows) the calling program
+        must guard its entry point with ``if __name__ == "__main__":``, as with
+        any use of multiprocessing.
+        """
+        chunks: List[List[EventFile]] = [[] for _ in range(self.processes)]
+        # Round-robin rather than contiguous: runs differ wildly in length, and
+        # dealing them out keeps a worker from drawing all the long ones.
+        for index, event_file in enumerate(event_files):
+            chunks[index % self.processes].append(event_file)
+        chunks = [chunk for chunk in chunks if chunk]
+        merged: Dict[AnalysisObject, AnalysisObject] = dict()
+        with ProcessPoolExecutor(max_workers=len(chunks)) as executor:
+            futures = [
+                executor.submit(analyze_files, self.model.factory, chunk)
+                for chunk in chunks
+            ]
+            for future in futures:
+                for analysis in future.result():
+                    known = merged.get(analysis)
+                    if known is None:
+                        merged[analysis] = analysis
+                    else:
+                        merge_analysis(known, analysis)
+        # The factory owns the objects the rest of the analyzer reads back.
+        self.model.factory.adopt(merged.values())
+
     def analyze(self):
         if self.meta:
             raise NotImplementedError("Not implemented for meta/loaded analyzer")
+        if self.processes > 1:
+            event_files = self.relevant_event_files + self.irrelevant_event_files
+            for event_file in event_files:
+                self.paths[event_file.run_id] = event_file.path
+            self._analyze_with_processes(event_files)
+            self._finalize()
+            return
         if self.workers > 1:
             event_files = self.relevant_event_files + self.irrelevant_event_files
             for event_file in event_files:

--- a/src/sflkit/analysis/factory.py
+++ b/src/sflkit/analysis/factory.py
@@ -1,6 +1,7 @@
 import abc
+from collections import OrderedDict
 from threading import Lock
-from typing import List, Type, Set
+from typing import Dict, FrozenSet, List, Optional, Set, Type
 
 from sflkitlib.events import EventType
 from sflkitlib.events.event import DefEvent
@@ -27,8 +28,27 @@ from sflkit.model.scope import Scope
 
 
 class AnalysisFactory(abc.ABC):
+    #: Event types this factory can produce analysis for. ``None`` means "any",
+    #: which is the safe default for a factory that has not declared itself.
+    #: :class:`CombinationFactory` uses this to skip factories that would only
+    #: look at the event type and return nothing: with a dozen factories
+    #: registered, all but one or two do exactly that for any given event.
+    EVENT_TYPES: Optional[FrozenSet[EventType]] = None
+
     def __init__(self):
         self.objects = dict()
+        self._lock = Lock()
+
+    def __getstate__(self) -> dict:
+        # Factories are shipped to worker processes to analyze a share of the
+        # runs. A lock is not picklable and guards nothing across processes,
+        # so it is dropped and remade on arrival.
+        state = dict(self.__dict__)
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
         self._lock = Lock()
 
     @abc.abstractmethod
@@ -47,6 +67,18 @@ class AnalysisFactory(abc.ABC):
     def reset(self, event_file: EventFile):
         pass
 
+    def exit_scope(self, event_file: EventFile, scope_id: int):
+        """
+        Release whatever this factory kept for a scope that has just ended.
+
+        :param event_file: The run.
+        :param scope_id: Identity of the scope being left.
+
+        Scope ids are handed out per function call, so a factory that keeps
+        state per scope grows with the number of calls a run makes unless it
+        is told when a scope dies.
+        """
+
     @staticmethod
     def default():
         return list()
@@ -54,28 +86,57 @@ class AnalysisFactory(abc.ABC):
     def get_all(self) -> Set[AnalysisObject]:
         return set(self.objects.values())
 
+    def adopt(self, objects) -> None:
+        """
+        Take ownership of analysis objects built elsewhere.
+
+        Used after a process-parallel run, where the objects were built in
+        worker processes and merged in the parent: the parent's own factories
+        never saw an event, so the merged objects are installed here for the
+        rest of the analyzer to read back.
+
+        :param objects: The objects to own.
+        """
+        self.objects = dict(enumerate(objects))
+
 
 class CombinationFactory(AnalysisFactory):
     def __init__(self, factories: List[AnalysisFactory]):
         super().__init__()
         self.factories = factories
+        self._dispatch: Dict[EventType, List[AnalysisFactory]] = {
+            event_type: [
+                factory
+                for factory in factories
+                if factory.EVENT_TYPES is None or event_type in factory.EVENT_TYPES
+            ]
+            for event_type in EventType
+        }
 
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
     ) -> List[AnalysisObject]:
-        return sum(
-            [factory.handle(event, event_file, scope) for factory in self.factories],
-            start=list(),
-        )
+        analysis = list()
+        for factory in self._dispatch.get(event.event_type, self.factories):
+            analysis.extend(factory.handle(event, event_file, scope))
+        return analysis
 
     def reset(self, event_file: EventFile):
         [f.reset(event_file) for f in self.factories]
 
+    def exit_scope(self, event_file: EventFile, scope_id: int):
+        for factory in self.factories:
+            factory.exit_scope(event_file, scope_id)
+
     def get_all(self) -> Set[AnalysisObject]:
-        return set().union(*map(lambda f: f.get_all(), self.factories))
+        return set(self.objects.values()).union(
+            *map(lambda f: f.get_all(), self.factories)
+        )
 
 
 class LineFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.LINE})
+
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
     ) -> List[AnalysisObject]:
@@ -89,6 +150,8 @@ class LineFactory(AnalysisFactory):
 
 
 class BranchFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.BRANCH})
+
     def __init__(self, else_: bool = True):
         super().__init__()
         self.else_ = else_
@@ -121,6 +184,8 @@ class BranchFactory(AnalysisFactory):
 
 
 class FunctionFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.FUNCTION_ENTER})
+
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
     ) -> List[AnalysisObject]:
@@ -134,6 +199,10 @@ class FunctionFactory(AnalysisFactory):
 
 
 class LoopFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset(
+        {EventType.LOOP_BEGIN, EventType.LOOP_HIT, EventType.LOOP_END}
+    )
+
     def __init__(self, hit_0: bool = True, hit_1: bool = True, hit_more: bool = True):
         super().__init__()
         self.hit_0 = hit_0
@@ -174,9 +243,20 @@ class LoopFactory(AnalysisFactory):
 
 
 class DefUseFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.DEF, EventType.USE})
+
+    #: How many cross-thread definitions to remember per run. The scope chain
+    #: answers every lookup within a thread, so this map only has to cover a
+    #: use whose definition happened in *another* thread, and it is bounded
+    #: because its key holds ``id(value)``: ids of dead objects would otherwise
+    #: accumulate for the length of the run, and worse, CPython recycles them,
+    #: so a stale entry can match an unrelated later object and invent a
+    #: def-use pair that never existed.
+    CROSS_THREAD_LIMIT = 4096
+
     def __init__(self):
         super().__init__()
-        self.id_to_def: dict[EventFile, dict[tuple[str, int], DefEvent]] = dict()
+        self.id_to_def: dict[EventFile, OrderedDict[tuple[str, int], DefEvent]] = dict()
         self.def_stack: dict[EventFile, dict[int, dict[tuple[str, int], DefEvent]]] = (
             dict()
         )
@@ -187,26 +267,92 @@ class DefUseFactory(AnalysisFactory):
         if event_file in self.def_stack:
             del self.def_stack[event_file]
 
+    def exit_scope(self, event_file: EventFile, scope_id: int):
+        """
+        Drop the definitions made in a scope that has ended.
+
+        Nothing can reach them any more: a use is resolved against the scope it
+        happens in, and that scope is gone. Without this the stack kept one
+        dict, and every ``DefEvent`` in it, for every function call the run
+        ever made.
+
+        :param event_file: The run.
+        :param scope_id: Identity of the scope being left.
+        """
+        scopes = self.def_stack.get(event_file)
+        if scopes is None:
+            return
+        definitions = scopes.pop(scope_id, None)
+        if not definitions:
+            return
+        cross_thread = self.id_to_def.get(event_file)
+        if cross_thread is None:
+            return
+        # A definition whose scope has ended has no business in the map that
+        # reaches scopes off this chain: left behind it resolves a later use
+        # against a scope that no longer exists, and since ids are recycled,
+        # possibly against an entirely unrelated object.
+        #
+        # Attributes are the exception, and they are why this map exists at
+        # all. `self.left = left` in a constructor is recorded as a definition
+        # of `self.left`, but its lifetime is the object's, not the frame's:
+        # every other method that reads it does so long after __init__ has
+        # returned. Dropping those with the scope would lose exactly the
+        # def-use pairs that span an object's methods. They stay, bounded by
+        # CROSS_THREAD_LIMIT.
+        #
+        # Only entries this scope still owns are removed; a later definition of
+        # the same name and id belongs to whichever scope overwrote it.
+        for key, event in definitions.items():
+            if "." in key[0]:
+                continue
+            if cross_thread.get(key) is event:
+                del cross_thread[key]
+
     def _find_def_event(
         self,
         event_file: EventFile,
-        scope_id: int,
+        scope: Optional[Scope],
         var_name: str,
         var_id: int,
-    ) -> DefEvent:
-        # Strategy 1: Check in scope
-        def_event = None
-        if event_file in self.def_stack and scope_id in self.def_stack[event_file]:
-            def_event = self.def_stack[event_file][scope_id].get(
-                (var_name, var_id), None
-            )
+    ) -> Optional[DefEvent]:
+        """
+        Find the definition a use refers to.
 
-        # Strategy 2: Look up in the global DEF stack (other threads)
-        if def_event is None:
-            if event_file in self.id_to_def:
-                def_event = self.id_to_def[event_file].get((var_name, var_id), None)
+        :param event_file: The run.
+        :param scope: The scope the use happens in.
+        :param var_name: Name of the used variable.
+        :param var_id: Identity of the value used.
+        :returns: The defining event, or ``None``.
 
-        return def_event
+        Resolution walks the scope chain outwards, which is what the language
+        itself does: a use sees its own scope first, then the scopes enclosing
+        it. Consulting only the innermost scope missed every definition made by
+        a caller, which is why a global map of every definition ever made was
+        needed as a fallback. That map now only has to answer for definitions
+        made in another thread, whose scopes are not on this chain.
+        """
+        key = (var_name, var_id)
+        scopes = self.def_stack.get(event_file)
+        if scopes:
+            current = scope
+            while current is not None:
+                definitions = scopes.get(current.id)
+                if definitions is not None:
+                    def_event = definitions.get(key)
+                    if def_event is not None:
+                        return def_event
+                current = current.parent
+            if scope is None:
+                definitions = scopes.get(0)
+                if definitions is not None:
+                    def_event = definitions.get(key)
+                    if def_event is not None:
+                        return def_event
+        cross_thread = self.id_to_def.get(event_file)
+        if cross_thread is not None:
+            return cross_thread.get(key)
+        return None
 
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
@@ -219,20 +365,22 @@ class DefUseFactory(AnalysisFactory):
 
             # Initialize structures if needed
             if event_file not in self.id_to_def:
-                self.id_to_def[event_file] = dict()
+                self.id_to_def[event_file] = OrderedDict()
             if event_file not in self.def_stack:
                 self.def_stack[event_file] = dict()
             if scope_id not in self.def_stack[event_file]:
                 self.def_stack[event_file][scope_id] = dict()
 
             # Store the DEF event
-            self.id_to_def[event_file][key] = event
+            cross_thread = self.id_to_def[event_file]
+            cross_thread[key] = event
+            cross_thread.move_to_end(key)
+            while len(cross_thread) > self.CROSS_THREAD_LIMIT:
+                cross_thread.popitem(last=False)
             self.def_stack[event_file][scope_id][key] = event
 
         elif event.event_type == EventType.USE:
-            def_event = self._find_def_event(
-                event_file, scope_id, event.var, event.var_id
-            )
+            def_event = self._find_def_event(event_file, scope, event.var, event.var_id)
 
             if def_event:
                 key = (
@@ -251,6 +399,8 @@ class DefUseFactory(AnalysisFactory):
 
 
 class ConditionFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.CONDITION})
+
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
     ) -> List[AnalysisObject]:
@@ -300,6 +450,32 @@ class ComparisonFactory(AnalysisFactory, abc.ABC):
 
 
 class ScalarPairFactory(ComparisonFactory):
+    EVENT_TYPES = frozenset({EventType.DEF})
+
+    def _pair(self, key, event, comp, var) -> AnalysisObject:
+        """
+        Return the scalar pair for *key*, creating it on first use.
+
+        The lock is only taken when the object is missing. Taking it on every
+        lookup cost one acquire per pair per event, and these objects are
+        created once and read forever after.
+
+        :param key: Identity of the pair.
+        :param event: The definition that triggered it.
+        :param comp: The comparison.
+        :param var: The variable compared against.
+        :returns: The analysis object.
+        """
+        analysis = self.objects.get(key)
+        if analysis is not None:
+            return analysis
+        with self._lock:
+            analysis = self.objects.get(key)
+            if analysis is None:
+                analysis = ScalarPair(event, comp, var)
+                self.objects[key] = analysis
+            return analysis
+
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
     ) -> List[AnalysisObject]:
@@ -320,24 +496,29 @@ class ScalarPairFactory(ComparisonFactory):
                             comparators = [
                                 c for c in comparators if c in (Comp.EQ, Comp.NE)
                             ]
+                        # Hoisted out of the loop: this body runs for every
+                        # pair of a definition and a variable in scope, which
+                        # is the densest inner loop in the analysis.
+                        analysis_type = ScalarPair.analysis_type()
+                        file = event.file
+                        line = event.line
+                        var = event.var
+                        type_ = types[0]
                         for variable in variables:
                             if variable.type_ in types:
                                 for comp in comparators:
                                     key = (
-                                        ScalarPair.analysis_type(),
-                                        event.file,
-                                        event.line,
-                                        event.var,
+                                        analysis_type,
+                                        file,
+                                        line,
+                                        var,
                                         variable.var,
-                                        comp,
-                                        types[0],
+                                        comp.value,
+                                        type_,
                                     )
-                                    with self._lock:
-                                        if key not in self.objects:
-                                            self.objects[key] = ScalarPair(
-                                                event, comp, variable.var
-                                            )
-                                    objects.append(self.objects[key])
+                                    objects.append(
+                                        self._pair(key, event, comp, variable.var)
+                                    )
             else:
                 for variable in variables:
                     if variable.type_ == event.type_:
@@ -363,6 +544,8 @@ class ScalarPairFactory(ComparisonFactory):
 
 
 class VariableFactory(ComparisonFactory):
+    EVENT_TYPES = frozenset({EventType.DEF})
+
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
     ) -> List[AnalysisObject]:
@@ -390,6 +573,8 @@ class VariableFactory(ComparisonFactory):
 
 
 class ReturnFactory(ComparisonFactory):
+    EVENT_TYPES = frozenset({EventType.FUNCTION_EXIT})
+
     def get_analysis(
         self, event, event_file: EventFile, scope: Scope = None
     ) -> List[AnalysisObject]:
@@ -460,6 +645,8 @@ class ReturnFactory(ComparisonFactory):
 
 
 class ConstantCompFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.DEF})
+
     def __init__(self, class_: Type[AnalysisObject]):
         super().__init__()
         self.class_ = class_
@@ -502,6 +689,8 @@ class EmptyBytesFactory(ConstantCompFactory):
 
 
 class PredicateFunctionFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.DEF})
+
     def __init__(self, class_: Type[AnalysisObject]):
         super().__init__()
         self.class_ = class_
@@ -540,6 +729,8 @@ class ContainsSpecialFactory(PredicateFunctionFactory):
 
 
 class LengthFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset({EventType.LEN})
+
     def __init__(
         self, length_0: bool = True, length_1: bool = True, length_more: bool = True
     ):
@@ -576,6 +767,10 @@ class LengthFactory(AnalysisFactory):
 
 
 class FunctionErrorFactory(AnalysisFactory):
+    EVENT_TYPES = frozenset(
+        {EventType.FUNCTION_ENTER, EventType.FUNCTION_ERROR, EventType.FUNCTION_EXIT}
+    )
+
     def __init__(self):
         super().__init__()
         self.function_mapping = dict()

--- a/src/sflkit/analysis/factory.py
+++ b/src/sflkit/analysis/factory.py
@@ -309,9 +309,20 @@ class ScalarPairFactory(ComparisonFactory):
             if event.type_ in ["int", "float", "bool", "str", "bytes"]:
                 for types in (["int", "float", "bool"], ["str"], ["bytes"]):
                     if event.type_ in types:
+                        # Ordered comparison is meaningful between numbers
+                        # but not between two unrelated strings: `<` on str is
+                        # lexicographic, so pairs like
+                        # `unique < request_queue_size` assert nothing about the
+                        # program while crowding out real causes. Equality still
+                        # distinguishes states, so keep EQ/NE.
+                        comparators = self.comparators
+                        if types[0] in ("str", "bytes"):
+                            comparators = [
+                                c for c in comparators if c in (Comp.EQ, Comp.NE)
+                            ]
                         for variable in variables:
                             if variable.type_ in types:
-                                for comp in self.comparators:
+                                for comp in comparators:
                                     key = (
                                         ScalarPair.analysis_type(),
                                         event.file,

--- a/src/sflkit/analysis/predicate.py
+++ b/src/sflkit/analysis/predicate.py
@@ -1,4 +1,5 @@
 import enum
+import operator
 from abc import ABC
 from typing import Tuple, Callable, Optional, List, Type, Any
 
@@ -69,8 +70,11 @@ class Predicate(Spectrum, ABC):
     def get_last_evaluation(
         self, id_: int, thread_id: Optional[int] = None
     ) -> EvaluationResult:
-        if id_ in self.last_evaluation and thread_id in self.last_evaluation[id_]:
-            return self.last_evaluation[id_][thread_id]
+        evaluations = self.last_evaluation.get(id_)
+        if evaluations is not None:
+            evaluation = evaluations.get(thread_id)
+            if evaluation is not None:
+                return evaluation
         return self.default_evaluation()
 
     def finalize(self, passed: list[EventFile], failed: list[EventFile]):
@@ -89,21 +93,29 @@ class Predicate(Spectrum, ABC):
                     self.false_relevant_observed()
 
     def hit(self, id_, event: Event, scope: Scope = None):
-        if id_ not in self.total_hits:
-            self.total_hits[id_] = dict()
-        if event.thread_id not in self.total_hits[id_]:
-            self.total_hits[id_][event.thread_id] = 0
-        if id_ not in self.hits:
-            self.hits[id_] = dict()
-            self.last_evaluation[id_] = dict()
-        if event.thread_id not in self.hits[id_]:
-            self.hits[id_][event.thread_id] = 0
-        self.total_hits[id_][event.thread_id] += 1
-        if self._evaluate_predicate(event, scope):
-            self.hits[id_][event.thread_id] += 1
-            self.last_evaluation[id_][event.thread_id] = EvaluationResult.TRUE
+        # The per-run dicts are fetched once each. Indexing them by run and
+        # then by thread on every access hashed the event file eight times per
+        # hit, which is millions of times over a trace.
+        thread_id = event.thread_id
+        total_hits = self.total_hits.get(id_)
+        if total_hits is None:
+            total_hits = self.total_hits[id_] = dict()
+        hits = self.hits.get(id_)
+        if hits is None:
+            hits = self.hits[id_] = dict()
+            last_evaluation = self.last_evaluation[id_] = dict()
         else:
-            self.last_evaluation[id_][event.thread_id] = EvaluationResult.FALSE
+            last_evaluation = self.last_evaluation[id_]
+        total_hits[thread_id] = total_hits.get(thread_id, 0) + 1
+        if self._evaluate_predicate(event, scope):
+            hits[thread_id] = hits.get(thread_id, 0) + 1
+            last_evaluation[thread_id] = EvaluationResult.TRUE
+        else:
+            # Still records the thread, so a run that only ever evaluated the
+            # predicate to false is distinguishable from one that never
+            # reached it.
+            hits.setdefault(thread_id, 0)
+            last_evaluation[thread_id] = EvaluationResult.FALSE
 
     def get_metric(self, metric: Callable = None, use_weight: bool = False):
         if metric is None:
@@ -290,26 +302,30 @@ class Comp(enum.Enum):
     NE = "!="
 
     def evaluate(self, x, y):
-        if self == Comp.LT:
-            return x < y
-        elif self == Comp.LE:
-            return x <= y
-        elif self == Comp.EQ:
-            return x == y
-        elif self == Comp.GE:
-            return x >= y
-        elif self == Comp.GT:
-            return x > y
-        elif self == Comp.NE:
-            return x != y
-        else:
-            raise ValueError(f"Unknown comparison operator: {self}")
+        # The operator is attached to each member below, so evaluating a
+        # comparison is one C-level call rather than a walk down a chain of
+        # identity tests. This runs once per predicate per event.
+        return self.function(x, y)
 
     def __repr__(self):
         return self.name
 
     def __str__(self):
         return self.name
+
+
+#: The operator each comparison stands for, attached to the member itself so
+#: :meth:`Comp.evaluate` needs neither a lookup nor a branch.
+for _member, _function in (
+    (Comp.LT, operator.lt),
+    (Comp.LE, operator.le),
+    (Comp.EQ, operator.eq),
+    (Comp.GE, operator.ge),
+    (Comp.GT, operator.gt),
+    (Comp.NE, operator.ne),
+):
+    _member.function = _function
+del _member, _function
 
 
 class Comparison(Predicate, ABC):

--- a/src/sflkit/analysis/spectra.py
+++ b/src/sflkit/analysis/spectra.py
@@ -1,7 +1,27 @@
 from abc import ABC
 from typing import Callable, Optional, Dict
 
-import numpy
+
+class _LazyNumpy:
+    """
+    Stands in for :mod:`numpy` until something actually needs it.
+
+    Only the similarity coefficients use numpy, and those run when
+    suspiciousness is scored, not while events are being collected. This module
+    is imported into every traced process, where numpy costs about 12 MB of
+    resident memory, so the import is deferred to first use. The first
+    attribute access replaces this proxy with the real module, so nothing pays
+    for it afterwards.
+    """
+
+    def __getattr__(self, name: str):
+        import numpy
+
+        globals()["numpy"] = numpy
+        return getattr(numpy, name)
+
+
+numpy = _LazyNumpy()
 
 from sflkit.analysis.analysis_type import (
     AnalysisObject,

--- a/src/sflkit/events/event_file.py
+++ b/src/sflkit/events/event_file.py
@@ -42,9 +42,7 @@ def open_event_stream(path: os.PathLike) -> io.BufferedReader:
                 f"{path} is zstd-compressed but the 'zstandard' package is not "
                 "installed. Run: pip install zstandard"
             ) from e
-        return io.BufferedReader(
-            zstandard.ZstdDecompressor().stream_reader(raw)
-        )
+        return io.BufferedReader(zstandard.ZstdDecompressor().stream_reader(raw))
     return raw
 
 
@@ -64,9 +62,26 @@ class EventFile(object):
         self.thread_support = thread_support
         self._csv_reader = None
         self._file_pointer = None
+        # Event files are the key of every per-run dict in the analysis layer,
+        # so this is hashed millions of times per run. The run id never
+        # changes, so the hash is computed once.
+        self._hash = hash(run_id)
+
+    def __getstate__(self) -> dict:
+        # Event files key the analysis layer's per-run state, so they travel
+        # with any result that crosses a process boundary. An open (or closed)
+        # file handle is not picklable and means nothing in another process,
+        # so it is dropped; reopening is what the context manager is for.
+        state = dict(self.__dict__)
+        state["_file_pointer"] = None
+        state["_csv_reader"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
 
     def __hash__(self):
-        return hash(self.run_id)
+        return self._hash
 
     def __eq__(self, other):
         if not isinstance(other, EventFile):

--- a/src/sflkit/events/event_file.py
+++ b/src/sflkit/events/event_file.py
@@ -1,9 +1,51 @@
+import io
 import os
 from pickle import PickleError
 
 from sflkitlib.events import event
 
 from sflkit.events.mapping import EventMapping
+
+GZIP_MAGIC = b"\x1f\x8b"
+ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+def open_event_stream(path: os.PathLike) -> io.BufferedReader:
+    """
+    Open an event file for reading, transparently decompressing it.
+
+    The runtime tracer may write the event stream through gzip or zstd, so the
+    codec is detected from the leading magic bytes rather than the file name.
+    The returned object always supports ``peek``, which the event reader relies
+    on to detect the end of the stream.
+
+    :param path: Path of the event file.
+    :returns: A buffered binary reader over the decoded event stream.
+    """
+    raw = open(path, "rb")
+    try:
+        header = raw.read(4)
+        raw.seek(0)
+    except OSError:
+        return raw
+
+    if header.startswith(GZIP_MAGIC):
+        import gzip
+
+        return io.BufferedReader(gzip.GzipFile(fileobj=raw, mode="rb"))
+    if header.startswith(ZSTD_MAGIC):
+        try:
+            import zstandard
+        except ImportError as e:
+            raw.close()
+            raise ImportError(
+                f"{path} is zstd-compressed but the 'zstandard' package is not "
+                "installed. Run: pip install zstandard"
+            ) from e
+        return io.BufferedReader(
+            zstandard.ZstdDecompressor().stream_reader(raw)
+        )
+    return raw
 
 
 class EventFile(object):
@@ -32,7 +74,7 @@ class EventFile(object):
         return self.run_id == other.run_id
 
     def __enter__(self):
-        self._file_pointer = open(self.path, "rb")
+        self._file_pointer = open_event_stream(self.path)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -45,14 +87,20 @@ class EventFile(object):
         return repr(self)
 
     def load(self):
-        while self._file_pointer.peek(1):
+        # A trace can end mid-stream: the run may have been killed by a timeout
+        # or have exhausted its trace budget. Every decoding error therefore
+        # ends the stream cleanly instead of failing the analysis; events read
+        # up to that point stay valid because events are written whole.
+        while True:
             try:
+                if not self._file_pointer.peek(1):
+                    break
                 e = event.load_next_event(
                     self._file_pointer,
                     self.mapping.mapping,
                     with_thread_id=self.thread_support,
                 )
-                if self.mapping.is_valid(e):
-                    yield e
-            except (IndexError, ValueError, PickleError, KeyError):
+            except (IndexError, ValueError, PickleError, KeyError, EOFError, OSError):
                 break
+            if self.mapping.is_valid(e):
+                yield e

--- a/src/sflkit/features/handler.py
+++ b/src/sflkit/features/handler.py
@@ -1,8 +1,7 @@
 import os.path
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from typing import List, Dict, Set, Optional
 
-import pandas as pd
 from sflkitlib.events.event import Event
 
 from sflkit.analysis.analysis_type import AnalysisObject, EvaluationResult
@@ -25,6 +24,8 @@ class FeatureBuilder(CombinationFactory):
         self.feature_vectors: Dict[EventFile, FeatureVector] = dict()
         self.all_features: Set[Feature] = set()
         self.name_map: Dict[EventFile, str] = dict()
+        #: Feature per analysis object, keyed by identity. See :meth:`_feature`.
+        self.features: Dict[int, Optional[Feature]] = dict()
 
     def __iter__(self) -> FeatureVector:
         yield from self.feature_vectors.values()
@@ -58,47 +59,99 @@ class FeatureBuilder(CombinationFactory):
         self.analysis[event_file].append(self)
         return self.analysis[event_file]
 
+    #: Evaluation results, and the bare booleans some analyses return, mapped
+    #: to feature values. A lookup replaces a `match` that ran once per
+    #: analysis object per event.
+    _EVALUATIONS = {
+        EvaluationResult.TRUE: FeatureValue.TRUE,
+        EvaluationResult.FALSE: FeatureValue.FALSE,
+        True: FeatureValue.TRUE,
+        False: FeatureValue.FALSE,
+    }
+
     @staticmethod
     def map_evaluation(
         analysis: Spectrum, id_: EventFile, thread_id: Optional[int] = None
     ):
-        match analysis.get_last_evaluation(id_, thread_id):
-            case EvaluationResult.TRUE:
-                return FeatureValue.TRUE
-            case EvaluationResult.FALSE:
-                return FeatureValue.FALSE
-            case True:
-                return FeatureValue.TRUE
-            case False:
-                return FeatureValue.FALSE
-            case _:
-                return FeatureValue.UNDEFINED
+        return FeatureBuilder._EVALUATIONS.get(
+            analysis.get_last_evaluation(id_, thread_id), FeatureValue.UNDEFINED
+        )
 
     def prepare(self, event_file: EventFile, test_result: TestResult):
         self.analysis[event_file] = list()
         self.name_map[event_file] = os.path.basename(str(event_file.path))
         self.feature_vectors[event_file] = FeatureVector(event_file, test_result)
 
+    def _feature(self, analysis: AnalysisObject) -> Optional[Feature]:
+        """
+        Return the feature standing for *analysis*, building it once.
+
+        An analysis object's feature never changes, but this used to be rebuilt
+        on every hit, and building it means formatting the object's name. On a
+        realistic trace that was millions of throwaway ``Feature`` objects and
+        name strings, which dominated the profile.
+
+        The cache is keyed by object identity and holds the feature, which in
+        turn references the analysis object, so an entry keeps its own key
+        alive and an id can never be recycled underneath it.
+
+        :param analysis: The analysis object.
+        :returns: Its feature, or ``None`` if it does not stand for one.
+        """
+        key = id(analysis)
+        try:
+            return self.features[key]
+        except KeyError:
+            pass
+        if isinstance(analysis, Predicate):
+            feature = TertiaryFeature(str(analysis), analysis)
+        elif isinstance(analysis, Spectrum):
+            feature = BinaryFeature(str(analysis), analysis)
+        else:
+            feature = None
+        self.features[key] = feature
+        return feature
+
     # noinspection PyUnusedLocal
     def hit(self, id_: EventFile, event: Event, *args, **kwargs):
+        vector = self.feature_vectors[id_]
+        # FeatureVector.set_feature keeps the FIRST value a feature is given
+        # for a run, so once this run has recorded a feature nothing can change
+        # it. Checking that up front skips reading the evaluation, taking the
+        # vector's lock and touching the feature set, which is the bulk of the
+        # work on all but the first hit of each feature.
+        recorded = vector.features
+        thread_id = event.thread_id
+        all_features = self.all_features
         for a in self.analysis[id_]:
-            if isinstance(a, Predicate):
-                feature = TertiaryFeature(str(a), a)
-                self.feature_vectors[id_].set_feature(
-                    feature, self.map_evaluation(a, id_, event.thread_id)
-                )
-                self.all_features.add(feature)
-            elif isinstance(a, Spectrum):
-                feature = BinaryFeature(str(a), a)
-                self.feature_vectors[id_].set_feature(
-                    feature, self.map_evaluation(a, id_, event.thread_id)
-                )
-                self.all_features.add(feature)
+            feature = self._feature(a)
+            if feature is None or feature in recorded:
+                continue
+            vector.set_feature(feature, self.map_evaluation(a, id_, thread_id))
+            all_features.add(feature)
+
+    def merge(self, other: "FeatureBuilder") -> None:
+        """
+        Fold a builder that handled other runs into this one.
+
+        Runs are independent, so what a worker built for its share is disjoint
+        from every other worker's and merges by union. Subclasses that
+        accumulate something across runs -- a call tree, say -- override this
+        and merge that too, which is what lets
+        :meth:`EventHandler.handle_files` spread any builder over processes
+        without knowing what it builds.
+
+        :param other: A builder that handled a different set of runs.
+        """
+        self.feature_vectors.update(other.feature_vectors)
+        self.name_map.update(other.name_map)
+        self.all_features.update(other.all_features)
 
     def copy(self):
         new_feature_builder = FeatureBuilder()
         new_feature_builder.all_features = set(self.all_features)
         new_feature_builder.feature_vectors = dict(self.feature_vectors)
+        new_feature_builder.features = dict(self.features)
         return new_feature_builder
 
     def to_complete_vectors(self, features: Optional[List[Feature]] = None):
@@ -114,6 +167,17 @@ class FeatureBuilder(CombinationFactory):
     def to_df(
         self, label: Optional[str] = None, features: Optional[List[Feature]] = None
     ):
+        """
+        Build a dataframe of the collected vectors.
+
+        pandas is imported here rather than at module scope because this is the
+        only thing in the module that needs it, while the module itself is
+        imported into every traced process: the collector runs inside the
+        program under test, where pandas costs 70 MB of resident memory and
+        280 ms of start-up per run and is never used.
+        """
+        import pandas as pd
+
         features = features or self.get_all_features()
         data = list()
         for vector in self:
@@ -126,8 +190,27 @@ class FeatureBuilder(CombinationFactory):
         return pd.DataFrame(data)
 
 
+def handle_files_in_process(
+    handler: "EventHandler", event_files: List[EventFile]
+) -> FeatureBuilder:
+    """
+    Handle a share of the runs in one process and return what was built.
+
+    At module level so it can be shipped to a worker.
+
+    :param handler: The handler to work with, carrying the builder to use.
+    :param event_files: The runs this worker is responsible for.
+    :returns: The builder, holding this share's results.
+    """
+    for event_file in event_files:
+        handler.handle(event_file)
+    return handler.builder
+
+
 class EventHandler:
-    def __init__(self, thread_support: bool = False, workers: int = 4):
+    def __init__(
+        self, thread_support: bool = False, workers: int = 4, processes: int = 1
+    ):
         self.builder = FeatureBuilder()
         self.thread_support = thread_support
         if thread_support:
@@ -135,6 +218,9 @@ class EventHandler:
         else:
             self.model = Model(self.builder)
         self.workers = workers
+        #: Worker processes to spread the runs over. Threads do not help:
+        #: building is Python-level work and the GIL serializes it.
+        self.processes = processes
 
     @staticmethod
     def map_result(failing: bool):
@@ -157,12 +243,57 @@ class EventHandler:
                 )
 
     def handle_files(self, event_files: List[EventFile]):
-        if self.workers > 1:
+        """
+        Handle every run in *event_files*.
+
+        :param event_files: The runs to handle.
+
+        With ``processes`` above one the runs are dealt out to worker
+        processes and each worker's builder is merged back. Callers on
+        platforms that spawn workers (macOS, Windows) must guard their entry
+        point with ``if __name__ == "__main__":``.
+
+        A builder that prunes against the failing runs seen so far cannot be
+        split this way unmodified: a worker only ever sees its own share, so
+        the failing runs it prunes against are only the ones it was dealt.
+
+        Call this on a handler that has not handled anything yet. Each worker
+        starts from a copy of this handler, so state already accumulated here
+        would be counted once per worker when the shares are merged back.
+        """
+        if self.processes > 1 and len(event_files) > 1:
+            self._handle_files_with_processes(event_files)
+        elif self.workers > 1:
             with ThreadPoolExecutor(max_workers=self.workers) as executor:
                 list(executor.map(self.handle, event_files))
         else:
             for e in event_files:
                 self.handle(e)
+
+    def _handle_files_with_processes(self, event_files: List[EventFile]):
+        """
+        Deal the runs out to worker processes and merge what they build.
+
+        :param event_files: The runs to handle.
+        """
+        chunks: List[List[EventFile]] = [[] for _ in range(self.processes)]
+        # Round-robin: runs differ wildly in length, so dealing them out keeps
+        # one worker from drawing all the long ones.
+        for index, event_file in enumerate(event_files):
+            chunks[index % self.processes].append(event_file)
+        chunks = [chunk for chunk in chunks if chunk]
+        with ProcessPoolExecutor(max_workers=len(chunks)) as executor:
+            futures = [
+                # `self`, not `self.copy()`: copy() rebuilds a plain
+                # FeatureBuilder and would silently downgrade a subclass --
+                # a tree builder would come back as a bare vector builder,
+                # having quietly built no tree. Pickling carries the real
+                # builder, its type and its configuration.
+                executor.submit(handle_files_in_process, self, chunk)
+                for chunk in chunks
+            ]
+            for future in futures:
+                self.builder.merge(future.result())
 
     def copy(self):
         new_handler = EventHandler()

--- a/src/sflkit/features/value.py
+++ b/src/sflkit/features/value.py
@@ -1,7 +1,29 @@
 import enum
+import hashlib
 from abc import abstractmethod, ABC
+from typing import Optional
 
 from sflkit.analysis.analysis_type import AnalysisObject
+
+
+def feature_id(name: str) -> int:
+    """
+    Stable 64-bit identifier for a feature *name*.
+
+    Deliberately not :func:`hash`: string hashing is randomized per process
+    (``PYTHONHASHSEED``), so built-in hashes of the same feature differ between
+    the worker that observed it and the parent that merges it. A digest of the
+    name is identical everywhere, which is what lets observations recorded in
+    separate processes be merged by id alone -- without shipping the feature's
+    analysis object, and therefore the whole analysis graph hanging off it,
+    across the process boundary.
+
+    :param name: Canonical feature name, e.g. ``"Line(main.py:12)"``.
+    :returns: The identifier.
+    """
+    return int.from_bytes(
+        hashlib.blake2b(name.encode("utf-8"), digest_size=8).digest(), "big"
+    )
 
 
 class FeatureValue(enum.Enum):
@@ -49,13 +71,28 @@ class Feature(ABC):
     def __init__(self, name: str, analysis: AnalysisObject):
         self.name = name
         self.analysis = analysis
+        self._id: Optional[int] = None
+        # Features key the feature vector, so this is hashed once per analysis
+        # object per event; the name never changes.
+        self._hash = hash(name)
+
+    @property
+    def id(self) -> int:
+        """
+        The feature's stable, process-independent identifier.
+
+        Computed from :attr:`name` on first access; see :func:`feature_id`.
+        """
+        if self._id is None:
+            self._id = feature_id(self.name)
+        return self._id
 
     @abstractmethod
     def default(self):
         raise NotImplementedError()
 
     def __hash__(self):
-        return hash(self.name)
+        return self._hash
 
     def __eq__(self, other):
         return hasattr(other, "name") and self.name == other.name

--- a/src/sflkit/features/vector.py
+++ b/src/sflkit/features/vector.py
@@ -17,6 +17,18 @@ class FeatureVector:
         self.features: Dict[Feature, FeatureValue] = dict()
         self._lock = Lock()
 
+    def __getstate__(self) -> dict:
+        # Feature vectors are pickled as part of the FORECAST relevance tree.
+        # A ``threading.Lock`` is not picklable and holds no persistent state,
+        # so drop it here and recreate it on unpickling.
+        state = dict(self.__dict__)
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = Lock()
+
     def get_features_set(self) -> Set[Feature]:
         with self._lock:
             return set(self.features.keys())

--- a/src/sflkit/features/vector.py
+++ b/src/sflkit/features/vector.py
@@ -42,10 +42,18 @@ class FeatureVector:
 
     def set_feature(self, feature: Feature, value: FeatureValue):
         with self._lock:
+            # Behaviour-preserving rewrite of
+            # ``self.features[feature] = self.features[feature] or value``.
+            # NOTE this keeps the FIRST value observed for a feature and
+            # discards every later one, because ``or`` is Python's boolean
+            # operator and every FeatureValue member -- including FALSE and
+            # UNDEFINED -- is truthy, so the left operand always wins. That is
+            # the established behaviour (tests/test_features.py asserts it),
+            # not the value-merging ``|`` that FeatureValue.__or__ defines.
+            # Expressed as a plain absence check it is also the cheapest form,
+            # which matters: this runs once per analysis object per event.
             if feature not in self.features:
                 self.features[feature] = value
-            else:
-                self.features[feature] = self.features[feature] or value
 
     def get_features(self) -> Dict[Feature, FeatureValue]:
         with self._lock:

--- a/src/sflkit/language/language.py
+++ b/src/sflkit/language/language.py
@@ -40,56 +40,105 @@ _PYTHON_FACTORIES = {
 }
 
 
+def _python_parts(visitor):
+    """
+    Build the Python backend's pieces.
+
+    :param visitor: Instrumentation visitor, or ``None`` where there is none.
+    :returns: Everything a :class:`Language` member exposes besides its
+        suffixes.
+    """
+    return (
+        visitor,
+        _PYTHON_FACTORIES,
+        PythonVarExtract(),
+        PythonVarExtract(use=True),
+        PythonConditionExtract(),
+        PythonFunctionFinder,
+        PythonLoopFinder,
+        PythonBranchFinder,
+    )
+
+
+def _no_parts():
+    """:returns: Empty pieces, for a language with no backend."""
+    return (None, dict(), None, None, None, None, None, None)
+
+
+#: Loaders, defined once so that members sharing one stay aliases of each other.
+_PYTHON_LOADER = lambda: _python_parts(PythonInstrumentation)
+_PYTHON2_LOADER = lambda: _python_parts(None)
+
+
 class Language(enum.Enum):
-    def __init__(
-        self,
-        ast_visitor: Type[ASTVisitor],
-        meta_visitors: Dict[EventType, Type[MetaVisitor]],
-        var_extract: VariableExtract,
-        use_extract: VariableExtract,
-        condition_extract: ConditionExtract,
-        function_finder: FunctionFinder,
-        loop_finder: LoopFinder,
-        branch_finder: BranchFinder,
-        suffixes: List[str],
-    ):
-        self.visitor = ast_visitor
-        self.meta_visitors = meta_visitors
-        self.var_extract = var_extract
-        self.use_extract = use_extract
-        self.condition_extract = condition_extract
-        self.function_finder = function_finder
-        self.loop_finder = loop_finder
-        self.branch_finder = branch_finder
+    """
+    A supported language and the backend that instruments it.
+
+    A member's backend is built the first time something asks for it, so
+    importing this module does not drag in every language's dependencies. Only
+    the suffixes are known up front, because that is all the file walker needs
+    to decide whether a language is relevant at all.
+    """
+
+    def __init__(self, loader, suffixes: List[str]):
+        self._loader = loader
+        self._parts = None
         self.suffixes = suffixes
+
+    def _load(self):
+        """:returns: The backend's pieces, built on first use."""
+        if self._parts is None:
+            self._parts = self._loader()
+        return self._parts
+
+    @property
+    def visitor(self) -> Type[ASTVisitor]:
+        """The instrumentation visitor."""
+        return self._load()[0]
+
+    @property
+    def meta_visitors(self) -> Dict[EventType, Type[MetaVisitor]]:
+        """Event factories, keyed by event type."""
+        return self._load()[1]
+
+    @property
+    def var_extract(self) -> VariableExtract:
+        """Extractor for defined variables."""
+        return self._load()[2]
+
+    @property
+    def use_extract(self) -> VariableExtract:
+        """Extractor for used variables."""
+        return self._load()[3]
+
+    @property
+    def condition_extract(self) -> ConditionExtract:
+        """Extractor for conditions."""
+        return self._load()[4]
+
+    @property
+    def function_finder(self) -> FunctionFinder:
+        """Finder locating a function in the source."""
+        return self._load()[5]
+
+    @property
+    def loop_finder(self) -> LoopFinder:
+        """Finder locating a loop in the source."""
+        return self._load()[6]
+
+    @property
+    def branch_finder(self) -> BranchFinder:
+        """Finder locating a branch in the source."""
+        return self._load()[7]
 
     def setup(self):
         AnalysisObject.set_finder(
             self.function_finder, self.loop_finder, self.branch_finder
         )
 
-    PYTHON = (
-        PythonInstrumentation,
-        _PYTHON_FACTORIES,
-        PythonVarExtract(),
-        PythonVarExtract(use=True),
-        PythonConditionExtract(),
-        PythonFunctionFinder,
-        PythonLoopFinder,
-        PythonBranchFinder,
-        ["py"],
-    )  # Equals PYTHON3
+    PYTHON = (_PYTHON_LOADER, ["py"])  # Equals PYTHON3
     PYTHON3 = PYTHON
-    PYTHON2 = (
-        None,
-        _PYTHON_FACTORIES,
-        PythonVarExtract(),
-        PythonVarExtract(use=True),
-        PythonConditionExtract(),
-        PythonFunctionFinder,
-        PythonLoopFinder,
-        PythonBranchFinder,
-        ["py"],
-    )
-    C = (None, dict(), None, None, None, None, None, None, ["c", "h"])
-    JAVA = (None, dict(), None, None, None, None, None, None, ["java"])
+    PYTHON2 = (_PYTHON2_LOADER, ["py"])
+    C = (_no_parts, ["c", "h"])
+    # Not wired on this line: the Java backend arrives with its own release.
+    JAVA = (_no_parts, ["java"])

--- a/src/sflkit/language/language.py
+++ b/src/sflkit/language/language.py
@@ -29,6 +29,7 @@ _PYTHON_FACTORIES = {
     EventType.FUNCTION_EXIT: python_factory.FunctionExitEventFactor,
     EventType.FUNCTION_ERROR: python_factory.FunctionErrorEventFactory,
     EventType.CONDITION: python_factory.ConditionEventFactory,
+    EventType.CONDITION_VALUE: python_factory.ConditionValueEventFactory,
     EventType.LEN: python_factory.LenEventFactory,
     EventType.TEST_START: python_factory.TestStartEventFactory,
     EventType.TEST_END: python_factory.TestEndEventFactory,

--- a/src/sflkit/language/python/factory.py
+++ b/src/sflkit/language/python/factory.py
@@ -26,7 +26,12 @@ from sflkitlib.events.event import (
 
 from sflkit.language.meta import MetaVisitor, Injection, IDGenerator, TmpGenerator
 
-python_lib = "sflkitlib.lib"
+python_lib_module = "sflkitlib.lib"
+# Dunder-shaped so namespace-cleanup idioms that keep only dunders and own
+# submodules (astropy/__init__.py) do not delete the tracer binding; a plain
+# name is deleted and the next probe raises NameError, killing the import.
+# Also one attribute lookup fewer per probe.
+python_lib = "__sflkitlib__"
 
 
 def get_call(function, *args) -> Expr:
@@ -772,19 +777,13 @@ class UseEventFactory(PythonEventFactory):
             body=[self._get_wrapped_property(event)],
             handlers=[
                 ExceptHandler(
-                    type=Tuple(
-                        elts=[
-                            Name(
-                                id="AttributeError",
-                            ),
-                            Name(
-                                id="TypeError",
-                            ),
-                            Name(
-                                id="NameError",
-                            ),
-                        ],
-                    ),
+                    # Any exception: evaluating a probe's own arguments runs
+                    # subject code (len() on a lazy proxy, attribute access via
+                    # __getattribute__) which can raise anything. Django's
+                    # settings raise ImproperlyConfigured when touched before
+                    # configuration, and a narrow guard let that abort the
+                    # import of the package under test.
+                    type=Name(id="Exception"),
                     name=None,
                     body=[Pass()],
                 ),
@@ -810,11 +809,28 @@ class UseEventFactory(PythonEventFactory):
         )
         return call
 
+    @staticmethod
+    def _get_type_of(class_: str) -> Call:
+        """
+        Build ``type(<class_>)``.
+
+        Deliberately ``type(x)`` and not ``x.__class__``: the two agree for
+        ordinary objects, but ``__class__`` is a normal attribute lookup and can
+        itself be a property. Django's lazy objects define
+        ``__class__ = property(new_method_proxy(...))``, so reading it re-enters
+        the proxy machinery this guard is meant to stay out of, recursing until
+        the stack is exhausted. ``type()`` reads the type slot directly and
+        cannot be proxied -- django's own source makes the same point: "We have
+        to use type(self), not self.__class__, because the latter is proxied."
+        """
+        return Call(func=Name(id="type"), args=[Name(id=class_)], keywords=[])
+
     def _get_wrapped_property(self, event: UseEvent):
         body = self._get_std_call(event)
         attributes = event.var.split(".")
         for i in range(len(attributes) - 1):
             class_ = ".".join(attributes[: -1 - i])
+            attribute = attributes[-1 - i]
             body = If(
                 test=BoolOp(
                     op=Or(),
@@ -826,9 +842,9 @@ class UseEventFactory(PythonEventFactory):
                                     id="hasattr",
                                 ),
                                 args=[
-                                    Name(id=class_ + ".__class__"),
+                                    self._get_type_of(class_),
                                     Constant(
-                                        value=attributes[-1 - i],
+                                        value=attribute,
                                     ),
                                 ],
                                 keywords=[],
@@ -841,8 +857,10 @@ class UseEventFactory(PythonEventFactory):
                                     id="isinstance",
                                 ),
                                 args=[
-                                    Name(
-                                        id=class_ + ".__class__." + attributes[-1 - i]
+                                    Attribute(
+                                        value=self._get_type_of(class_),
+                                        attr=attribute,
+                                        ctx=Load(),
                                     ),
                                     Name(
                                         id="property",
@@ -1009,19 +1027,13 @@ class LenEventFactory(DefEventFactory):
             body=[call],
             handlers=[
                 ExceptHandler(
-                    type=Tuple(
-                        elts=[
-                            Name(
-                                id="AttributeError",
-                            ),
-                            Name(
-                                id="TypeError",
-                            ),
-                            Name(
-                                id="NameError",
-                            ),
-                        ],
-                    ),
+                    # Any exception: evaluating a probe's own arguments runs
+                    # subject code (len() on a lazy proxy, attribute access via
+                    # __getattribute__) which can raise anything. Django's
+                    # settings raise ImproperlyConfigured when touched before
+                    # configuration, and a narrow guard let that abort the
+                    # import of the package under test.
+                    type=Name(id="Exception"),
                     name=None,
                     body=[Pass()],
                 )

--- a/src/sflkit/language/python/factory.py
+++ b/src/sflkit/language/python/factory.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import typing
 from ast import *
 
@@ -15,6 +16,7 @@ from sflkitlib.events.event import (
     LoopEndEvent,
     UseEvent,
     ConditionEvent,
+    ConditionValueEvent,
     LenEvent,
     TestStartEvent,
     TestEndEvent,
@@ -995,6 +997,89 @@ class ConditionEventFactory(PythonEventFactory):
 
     def visit_If(self, node: If) -> Injection:
         return self.visit_condition(node)
+
+
+class ConditionValueEventFactory(PythonEventFactory):
+    """Emit a branch-distance companion event for single-comparison conditions.
+
+    For an ``if``/``while`` whose test is a lone comparison ``lhs <op> rhs`` with
+    side-effect-free operands, inject a call that reports the operands to the
+    runtime, which computes the branch distance. The original test is left
+    untouched (the plain :class:`ConditionEventFactory` still records its
+    boolean), so this is purely additive; compound tests, non-comparison tests,
+    and tests with side-effecting operands are skipped and fall back to the
+    boolean condition event plus approach-level guidance.
+    """
+
+    _OPS = {
+        ast.Lt: "<",
+        ast.LtE: "<=",
+        ast.Gt: ">",
+        ast.GtE: ">=",
+        ast.Eq: "==",
+        ast.NotEq: "!=",
+    }
+
+    def get_function(self):
+        return "add_condition_value_event"
+
+    @staticmethod
+    def _is_pure(node: AST) -> bool:
+        # Operands we can safely re-evaluate: no calls, subscripts, or operators
+        # that could have side effects.
+        if isinstance(node, Constant):
+            return True
+        if isinstance(node, Name):
+            return True
+        if isinstance(node, Attribute):
+            return ConditionValueEventFactory._is_pure(node.value)
+        if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):
+            return ConditionValueEventFactory._is_pure(node.operand)
+        return False
+
+    def _capturable(self, test: AST):
+        if not isinstance(test, Compare) or len(test.ops) != 1:
+            return None
+        op = self._OPS.get(type(test.ops[0]))
+        if op is None:
+            return None
+        lhs, rhs = test.left, test.comparators[0]
+        if not (self._is_pure(lhs) and self._is_pure(rhs)):
+            return None
+        return op, lhs, rhs
+
+    def _get_event_call(self, event: ConditionValueEvent, op: str, lhs, rhs):
+        # sflkitlib.lib.add_condition_value_event(event_id, lhs, rhs, "op")
+        call = get_call(self.get_function(), event.event_id)
+        assert isinstance(call.value, Call)
+        call.value.args.append(copy.deepcopy(lhs))
+        call.value.args.append(copy.deepcopy(rhs))
+        call.value.args.append(Constant(value=op))
+        return call
+
+    def visit_condition(self, node: typing.Union[If, While]) -> Injection:
+        capturable = self._capturable(node.test)
+        if capturable is None:
+            return Injection()
+        op, lhs, rhs = capturable
+        event = ConditionValueEvent(
+            self.file,
+            node.lineno,
+            self.event_id_generator.get_next_id(),
+            ast.unparse(node.test),
+            op,
+        )
+        return Injection(
+            pre=[self._get_event_call(event, op, lhs, rhs)], events=[event]
+        )
+
+    def visit_If(self, node: If) -> Injection:
+        return self.visit_condition(node)
+
+    def visit_While(self, node: While) -> Injection:
+        injection = self.visit_condition(node)
+        injection.body_last = injection.pre
+        return injection
 
 
 class LenEventFactory(DefEventFactory):

--- a/src/sflkit/language/python/visitor.py
+++ b/src/sflkit/language/python/visitor.py
@@ -3,7 +3,7 @@ from typing import Any, Union
 
 from sflkit.language.meta import MetaVisitor, Injection
 from sflkit.language.python.extract import PythonIsDoc
-from sflkit.language.python.factory import python_lib
+from sflkit.language.python.factory import python_lib, python_lib_module
 from sflkit.language.visitor import ASTVisitor
 
 
@@ -28,7 +28,7 @@ class PythonInstrumentation(NodeTransformer, ASTVisitor):
             body=doc
             + self.__future__
             + [
-                Import(names=[alias(name=python_lib, asname=None)]),
+                Import(names=[alias(name=python_lib_module, asname=python_lib)]),
                 instrumented_tree,
             ],
             type_ignores=list(),

--- a/src/sflkit/model/model.py
+++ b/src/sflkit/model/model.py
@@ -58,11 +58,24 @@ class Model:
         event: Event,
         event_file: EventFile,
         scope: Scope = None,
-    ) -> Set[AnalysisObject]:
+    ) -> List[AnalysisObject]:
+        """
+        Dispatch one event to the analysis objects it concerns.
+
+        :param event: The event.
+        :param event_file: The run it belongs to.
+        :param scope: Variable scope, where the event type carries one.
+        :returns: The analysis objects that were hit.
+
+        Returns the list as built. It used to return ``set(analysis)``, which
+        hashed every analysis object on every event -- and a ScalarPair hash
+        builds and hashes a six-element tuple -- while every caller in the
+        dispatch below discards the result.
+        """
         analysis = self.factory.handle(event, event_file, scope=scope)
         for a in analysis:
             a.hit(event_file, event, scope=scope)
-        return set(analysis)
+        return analysis
 
     def handle_line_event(self, event: LineEvent, event_file: EventFile):
         self.handle_event(event, event_file)
@@ -133,7 +146,11 @@ class Model:
         self.variables[event_file] = self.variables[event_file].enter()
 
     def exit_scope(self, event_file: EventFile):
-        self.variables[event_file] = self.variables[event_file].exit()
+        scope = self.variables[event_file]
+        # Tell the factories before the scope is dropped, so anything they keep
+        # per scope can go with it.
+        self.factory.exit_scope(event_file, scope.id)
+        self.variables[event_file] = scope.exit()
 
     # noinspection PyUnresolvedReferences
     def get_analysis(self) -> Set[AnalysisObject]:

--- a/src/sflkit/model/parallel.py
+++ b/src/sflkit/model/parallel.py
@@ -19,8 +19,13 @@ class ParallelModel(Model):
 
     def prepare(self, event_file: EventFile):
         super().prepare(event_file)
-        self.variables_map = dict()
-        self.returns_map = dict()
+        # Keyed by event file, like every other per-run map on the model.
+        # Rebinding the whole dict here left `variables_map[event_file]`
+        # missing, so the first def or use carrying a thread id raised
+        # KeyError, and it also discarded the state of files still being
+        # processed in parallel.
+        self.variables_map[event_file] = dict()
+        self.returns_map[event_file] = dict()
 
     def handle_function_enter_event(
         self, event: FunctionEnterEvent, event_file: EventFile
@@ -92,8 +97,8 @@ class ParallelModel(Model):
         )
 
     def exit_parallel_scope(self, thread_id: int, event_file: EventFile):
-        self.variables_map[event_file][thread_id] = (
-            self.variables_map[event_file]
-            .get(thread_id, self.variables[event_file])
-            .exit()
+        scope = self.variables_map[event_file].get(
+            thread_id, self.variables[event_file]
         )
+        self.factory.exit_scope(event_file, scope.id)
+        self.variables_map[event_file][thread_id] = scope.exit()

--- a/src/sflkit/online/__init__.py
+++ b/src/sflkit/online/__init__.py
@@ -1,0 +1,57 @@
+"""
+Building analysis artifacts while the program under test runs.
+
+The offline workflow stays as it is: instrument, execute, write a trace, read
+it back. This package adds a second one that skips the trace entirely. A
+tracer materializes the same events from CPython's monitoring hooks and the
+static event mapping, and listeners turn them into spectra, feature vectors and
+a call tree as they arrive.
+
+What it buys: no trace on disk and none in memory, no second pass over the
+events, and a run that executes the program as shipped rather than an
+instrumented copy of it. What it costs: slower execution, since every observed
+location goes through a Python callback, and two event types that cannot be
+recovered from outside the program (see :mod:`sflkit.online.tracer`).
+"""
+
+from sflkit.online.listener import (
+    BuilderListener,
+    EventListener,
+    ListenerGroup,
+    ModelListener,
+    OnlineError,
+    SpectrumListener,
+    spectrum_factory,
+)
+from sflkit.online.session import OnlineSession, RunArtifact, Suite, trace
+from sflkit.online.tracer import (
+    LocationIndex,
+    MonitoringTracer,
+    SUPPORTED_EVENT_TYPES,
+    SysTraceTracer,
+    Tracer,
+    get_tracer,
+)
+from sflkit.online.tree import TreeBuilder, TreeNode
+
+__all__ = [
+    "BuilderListener",
+    "EventListener",
+    "ListenerGroup",
+    "LocationIndex",
+    "ModelListener",
+    "MonitoringTracer",
+    "OnlineError",
+    "OnlineSession",
+    "RunArtifact",
+    "SUPPORTED_EVENT_TYPES",
+    "SpectrumListener",
+    "Suite",
+    "SysTraceTracer",
+    "Tracer",
+    "TreeBuilder",
+    "TreeNode",
+    "get_tracer",
+    "spectrum_factory",
+    "trace",
+]

--- a/src/sflkit/online/listener.py
+++ b/src/sflkit/online/listener.py
@@ -1,0 +1,266 @@
+"""
+Listeners that build analysis artifacts while the program under test runs.
+
+The offline pipeline serializes every event to disk and reads the whole trace
+back to build spectra, feature vectors and relevance trees.  A listener
+consumes the same :class:`~sflkitlib.events.event.Event` objects as they are
+produced, so the artifact is finished the moment the run terminates: nothing is
+written and nothing is read back.
+
+Listeners are deliberately thin.  Each owns a :class:`~sflkit.model.model.Model`
+and feeds it exactly what :meth:`sflkit.analysis.analyzer.Analyzer._analyze`
+feeds it offline -- ``prepare``, one ``handle`` per event, ``follow_up`` -- so
+the analysis layer cannot tell the two sources apart and every spectrum,
+predicate and feature keeps its offline meaning.  That is what makes the two
+workflows comparable: an online artifact is not an approximation of the offline
+one, it is the same computation with the disk round-trip removed.
+"""
+
+import abc
+from typing import Iterable, List, Optional, Set
+
+from sflkitlib.events.event import Event
+
+from sflkit.analysis.analysis_type import AnalysisObject, AnalysisType
+from sflkit.analysis.factory import (
+    AnalysisFactory,
+    CombinationFactory,
+    analysis_factory_mapping,
+)
+from sflkit.events.event_file import EventFile
+from sflkit.features.handler import EventHandler, FeatureBuilder
+from sflkit.model.model import Model
+from sflkit.model.parallel import ParallelModel
+
+
+class OnlineError(RuntimeError):
+    """Raised when a listener is driven out of order."""
+
+
+def spectrum_factory(
+    types: Optional[Iterable[AnalysisType]] = None,
+) -> AnalysisFactory:
+    """
+    Build the analysis factory for *types*, or for every analysis type.
+
+    :param types: Analysis types to collect.  ``None`` collects all of them,
+        which is what :class:`~sflkit.features.handler.FeatureBuilder` does.
+    :returns: A factory combining one sub-factory per requested type.
+    """
+    if types is None:
+        types = analysis_factory_mapping.keys()
+    return CombinationFactory([analysis_factory_mapping[t]() for t in types])
+
+
+class EventListener(abc.ABC):
+    """
+    Receives a run's events as they happen.
+
+    The contract is a single run: :meth:`start`, any number of :meth:`event`
+    calls, then :meth:`stop`.  A listener may be reused for the next run after
+    :meth:`stop` returns.
+    """
+
+    def start(self, run: EventFile) -> None:
+        """
+        Begin a run.
+
+        :param run: Identity of the run about to be traced.  This is an
+            :class:`~sflkit.events.event_file.EventFile` even though no file is
+            involved: the analysis layer keys all of its per-run state by it,
+            and it is never opened, so it costs nothing to reuse the type
+            rather than introduce a parallel one that every ``dict`` would then
+            have to accept.
+        """
+
+    @abc.abstractmethod
+    def event(self, event: Event) -> None:
+        """
+        Consume one event of the current run.
+
+        :param event: A fully instantiated event, indistinguishable from one
+            decoded off a trace file.
+        """
+
+    def stop(self) -> None:
+        """Finish the current run."""
+
+
+class ModelListener(EventListener):
+    """
+    Drives a :class:`~sflkit.model.model.Model` from a live event stream.
+
+    :ivar factory: The analysis factory the model dispatches to.
+    :ivar model: Serial or parallel model, depending on ``thread_support``.
+    :ivar run: The run currently being traced, or ``None`` between runs.
+    """
+
+    def __init__(
+        self,
+        factory: AnalysisFactory,
+        thread_support: bool = False,
+        workers: int = 4,
+    ):
+        """
+        :param factory: Analysis factory to dispatch events to.
+        :param thread_support: Use :class:`~sflkit.model.parallel.ParallelModel`,
+            which keeps one scope per thread id.
+        :param workers: Worker threads used when finalizing analysis objects.
+        """
+        self.factory = factory
+        self.thread_support = thread_support
+        self.model: Model = (
+            ParallelModel(factory, workers=workers)
+            if thread_support
+            else Model(factory, workers=workers)
+        )
+        self.run: Optional[EventFile] = None
+
+    def start(self, run: EventFile) -> None:
+        self.run = run
+        self.model.prepare(run)
+
+    def event(self, event: Event) -> None:
+        if self.run is None:
+            raise OnlineError("event() before start(): no run is being traced")
+        event.handle(self.model, self.run)
+
+    def stop(self) -> None:
+        if self.run is None:
+            return
+        self.model.follow_up(self.run)
+        self.run = None
+
+
+class SpectrumListener(ModelListener):
+    """
+    Builds spectra and predicates online, the way
+    :class:`~sflkit.analysis.analyzer.Analyzer` builds them offline.
+
+    Suspiciousness is a whole-suite property, so it is not available until
+    every run has been seen: call :meth:`finalize` once, with all runs, before
+    reading :attr:`analysis`.
+    """
+
+    def __init__(
+        self,
+        types: Optional[Iterable[AnalysisType]] = None,
+        factory: Optional[AnalysisFactory] = None,
+        thread_support: bool = False,
+        workers: int = 4,
+    ):
+        """
+        :param types: Analysis types to collect.  Ignored when *factory* is given.
+        :param factory: Pre-built factory, e.g. ``config.factory``.
+        :param thread_support: See :class:`ModelListener`.
+        :param workers: See :class:`ModelListener`.
+        """
+        super().__init__(
+            factory if factory is not None else spectrum_factory(types),
+            thread_support=thread_support,
+            workers=workers,
+        )
+
+    @property
+    def analysis(self) -> Set[AnalysisObject]:
+        """Every analysis object observed so far, across all runs."""
+        return self.model.get_analysis()
+
+    def finalize(
+        self,
+        passing: Optional[List[EventFile]] = None,
+        failing: Optional[List[EventFile]] = None,
+    ) -> None:
+        """
+        Compute suspiciousness over the collected runs.
+
+        :param passing: The passing runs.
+        :param failing: The failing runs.
+        """
+        self.model.finalize(passing, failing)
+
+
+class BuilderListener(ModelListener):
+    """
+    Builds feature vectors online, and anything else a
+    :class:`~sflkit.features.handler.FeatureBuilder` subclass builds.
+
+    FORECAST's ``TreeBuilder`` is such a subclass, so passing one here builds
+    the relevance tree during execution instead of from event files; this
+    listener calls its ``post_process`` hook on :meth:`stop` exactly as
+    ``ForecastHandler.handle`` calls it after draining an event file.
+
+    :ivar builder: The builder receiving ``prepare``/``hit``/``post_process``.
+    """
+
+    def __init__(
+        self,
+        builder: Optional[FeatureBuilder] = None,
+        thread_support: bool = False,
+        workers: int = 4,
+    ):
+        """
+        :param builder: Builder to drive.  Defaults to a plain
+            :class:`~sflkit.features.handler.FeatureBuilder`, which yields one
+            feature vector per run.
+        :param thread_support: See :class:`ModelListener`.
+        :param workers: See :class:`ModelListener`.
+        """
+        self.builder = builder if builder is not None else FeatureBuilder()
+        super().__init__(self.builder, thread_support=thread_support, workers=workers)
+
+    def start(self, run: EventFile) -> None:
+        super().start(run)
+        self.builder.prepare(run, EventHandler.map_result(run.failing))
+
+    def stop(self) -> None:
+        run = self.run
+        super().stop()
+        # TreeBuilder records the root exit vector here; FeatureBuilder has no
+        # such hook. Mirrors ForecastHandler.handle, which post-processes after
+        # the event loop rather than inside it.
+        post_process = getattr(self.builder, "post_process", None)
+        if run is not None and post_process is not None:
+            post_process(run)
+
+
+class ListenerGroup(EventListener):
+    """
+    Fans one event stream out to several listeners.
+
+    This is what makes "all at the same time" cheap: spectra, feature vectors
+    and the relevance tree are built from a single execution, because the cost
+    that dominates is producing the events, not consuming them.
+
+    :ivar listeners: The listeners, notified in order.
+    """
+
+    def __init__(self, *listeners: EventListener):
+        """
+        :param listeners: Listeners to drive, in order.
+        """
+        self.listeners: List[EventListener] = list(listeners)
+
+    def add(self, listener: EventListener) -> EventListener:
+        """
+        Append *listener* to the group.
+
+        :param listener: The listener to add.
+        :returns: The listener, so callers can keep a handle on it inline.
+        """
+        self.listeners.append(listener)
+        return listener
+
+    def start(self, run: EventFile) -> None:
+        for listener in self.listeners:
+            listener.start(run)
+
+    def event(self, event: Event) -> None:
+        for listener in self.listeners:
+            listener.event(event)
+
+    def stop(self) -> None:
+        # Reverse order so a listener that wraps another still sees a live
+        # inner listener while finishing up.
+        for listener in reversed(self.listeners):
+            listener.stop()

--- a/src/sflkit/online/plugin.py
+++ b/src/sflkit/online/plugin.py
@@ -1,0 +1,187 @@
+"""
+pytest plugin that builds an artifact per test instead of a trace.
+
+Loaded with ``-p sflkit.online.plugin`` and configured entirely through the
+environment, because the runner starts pytest in a subprocess and the plugin
+has to configure itself before any test runs.
+
+One tracer serves the whole pytest process and one artifact is written per
+test, named and filed exactly where the offline runner would have put that
+test's trace. A process may therefore run the entire suite and still produce
+per-test evidence, which is what makes it possible to drop the
+process-per-test model later without changing anything downstream.
+
+Environment:
+
+``SFLKIT_ONLINE_MAPPING``
+    Path to the event mapping written by instrumentation. Required.
+``SFLKIT_ONLINE_ROOT``
+    Directory the mapping's file names are relative to. Required.
+``SFLKIT_ONLINE_OUTPUT``
+    Directory to write artifacts into, under ``passing``/``failing``/
+    ``undefined``. Required.
+``SFLKIT_ONLINE_THREADS``
+    ``1`` to trace threads and stamp events with a thread id.
+``SFLKIT_ONLINE_TREE``
+    ``0`` to skip building the call tree.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+from sflkit.events.mapping import EventMapping
+from sflkit.logger import LOGGER
+from sflkit.online.session import OnlineSession
+from sflkit.online.tracer import LocationIndex
+from sflkit.runners.run import Runner, TestResult
+
+#: Environment variable holding the event mapping path.
+MAPPING = "SFLKIT_ONLINE_MAPPING"
+#: Environment variable holding the subject root.
+ROOT = "SFLKIT_ONLINE_ROOT"
+#: Environment variable holding the artifact output directory.
+OUTPUT = "SFLKIT_ONLINE_OUTPUT"
+#: Environment variable enabling thread support.
+THREADS = "SFLKIT_ONLINE_THREADS"
+#: Environment variable disabling tree construction.
+TREE = "SFLKIT_ONLINE_TREE"
+
+
+def _flag(name: str, default: bool) -> bool:
+    """
+    :param name: Environment variable to read.
+    :param default: Value to use when it is unset.
+    :returns: The variable read as a boolean.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "t", "y")
+
+
+class OnlineCollector:
+    """
+    Traces each test and writes its artifact.
+
+    :ivar index: Location index, built once and shared by every test.
+    :ivar output: Where artifacts are written.
+    :ivar session: The session tracing the test currently running.
+    :ivar results: Verdict per test id, filled in as reports come in.
+    """
+
+    def __init__(
+        self, index: LocationIndex, output: Path, thread_support: bool, tree: bool
+    ):
+        """
+        :param index: Location index for the subject.
+        :param output: Directory to write artifacts into.
+        :param thread_support: Trace threads.
+        :param tree: Build the call tree.
+        """
+        self.index = index
+        self.output = output
+        self.thread_support = thread_support
+        self.tree = tree
+        self.session: Optional[OnlineSession] = None
+        self.results: Dict[str, TestResult] = dict()
+        self._run_id = 0
+
+    def start(self, test: str) -> None:
+        """
+        Begin tracing *test*.
+
+        :param test: The test's node id.
+        """
+        # A fresh session per test keeps each artifact independent, which is
+        # what lets the parent merge them in any order it likes. The index is
+        # shared because building it parses every source file.
+        self.session = OnlineSession(
+            index=self.index,
+            thread_support=self.thread_support,
+            tree=self.tree,
+        )
+        self.session.start(test, failing=None, run_id=self._run_id)
+        self._run_id += 1
+
+    def stop(self, test: str) -> None:
+        """
+        Finish *test* and write its artifact.
+
+        :param test: The test's node id.
+        """
+        if self.session is None:
+            return
+        session, self.session = self.session, None
+        try:
+            session.stop()
+        except Exception:
+            LOGGER.exception("Could not stop tracing %s", test)
+            return
+        result = self.results.get(test, TestResult.UNDEFINED)
+        artifact = session.artifact()
+        artifact.result = result
+        directory = self.output / result.get_dir()
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+            artifact.dump(directory / Runner.safe(test))
+        except OSError:
+            LOGGER.exception("Could not write the artifact for %s", test)
+
+
+_collector: Optional[OnlineCollector] = None
+
+
+def pytest_configure(config):
+    """Build the shared index once, before any test runs."""
+    global _collector
+    mapping_path = os.environ.get(MAPPING)
+    root = os.environ.get(ROOT)
+    output = os.environ.get(OUTPUT)
+    if not (mapping_path and root and output):
+        LOGGER.warning(
+            "sflkit online plugin loaded without %s, %s and %s; not tracing",
+            MAPPING,
+            ROOT,
+            OUTPUT,
+        )
+        return
+    try:
+        mapping = EventMapping.load_from_file(Path(mapping_path), root)
+        _collector = OnlineCollector(
+            LocationIndex(mapping, root),
+            Path(output),
+            _flag(THREADS, False),
+            _flag(TREE, True),
+        )
+    except Exception:
+        # Collecting must never be the reason a test suite fails to run: a
+        # misconfigured collector costs evidence, not the run.
+        LOGGER.exception("Could not set up online collection; not tracing")
+        _collector = None
+
+
+def pytest_runtest_setup(item):
+    """Start tracing before the test body runs."""
+    if _collector is not None:
+        _collector.start(item.nodeid)
+
+
+def pytest_runtest_logreport(report):
+    """
+    Record the verdict of the test body.
+
+    Only the call phase decides pass or fail; a failure during setup or
+    teardown leaves the verdict undefined, which is what it is.
+    """
+    if _collector is None or report.when != "call":
+        return
+    _collector.results[report.nodeid] = (
+        TestResult.PASSING if report.passed else TestResult.FAILING
+    )
+
+
+def pytest_runtest_teardown(item, nextitem):
+    """Stop tracing and write the artifact."""
+    if _collector is not None:
+        _collector.stop(item.nodeid)

--- a/src/sflkit/online/session.py
+++ b/src/sflkit/online/session.py
@@ -1,0 +1,349 @@
+"""
+Driving a traced run and shipping what it produced.
+
+Collectors live inside the process that runs the test, so a run ends with the
+artifact already built. What crosses the process boundary afterwards is that
+artifact -- a per-run feature record and, optionally, a call tree -- rather
+than a raw event stream. The size difference is the point: a trace grows with
+the number of events executed, an artifact with the number of program points
+observed.
+
+Typical use inside the test process::
+
+    with trace(mapping, root, name=test, failing=True) as session:
+        run_the_test()
+    session.artifact().dump(out / test)
+
+and in the parent, once every test has run::
+
+    suite = Suite.merge(RunArtifact.load(p) for p in paths)
+"""
+
+import gzip
+import os
+import pickle
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from sflkit.analysis.analysis_type import AnalysisType
+from sflkit.events.event_file import EventFile
+from sflkit.events.mapping import EventMapping
+from sflkit.features.value import FeatureValue
+from sflkit.online.listener import (
+    BuilderListener,
+    ListenerGroup,
+    SpectrumListener,
+)
+from sflkit.online.tracer import LocationIndex, Tracer, get_tracer
+from sflkit.online.tree import TreeBuilder, TreeNode
+from sflkit.runners.run import TestResult
+
+#: Leading bytes of a gzip stream, used to detect compressed artifacts.
+_GZIP_MAGIC = b"\x1f\x8b"
+
+
+class RunArtifact:
+    """
+    Everything one traced run contributes to the analysis.
+
+    :ivar run: Name of the run, usually the test id.
+    :ivar result: Whether the run passed, failed, or neither.
+    :ivar features: Feature id to :class:`~sflkit.features.value.FeatureValue`
+        value observed in this run. This single record serves both purposes:
+        it is the run's feature vector, and it is the per-run spectrum from
+        which pass/fail counts are aggregated.
+    :ivar catalog: Feature id to feature name.
+    :ivar tree: The run's call tree, when one was built.
+    """
+
+    def __init__(
+        self,
+        run: str,
+        result: TestResult,
+        features: Dict[int, int],
+        catalog: Dict[int, str],
+        tree: Optional[TreeNode] = None,
+    ):
+        self.run = run
+        self.result = result
+        self.features = features
+        self.catalog = catalog
+        self.tree = tree
+
+    def __repr__(self):
+        return (
+            f"RunArtifact({self.run}, {self.result.name}, "
+            f"features={len(self.features)})"
+        )
+
+    def dump(self, path: os.PathLike | str, compress: bool = True) -> None:
+        """
+        Write the artifact to *path*.
+
+        :param path: Destination.
+        :param compress: gzip the pickle, which is worth it because feature
+            records repeat heavily across runs.
+
+        The write is atomic: a killed process leaves either the previous
+        artifact or nothing, never a plausible-looking truncated one.
+        """
+        opener = gzip.open if compress else open
+        target = os.fspath(path)
+        tmp = f"{target}.tmp"
+        try:
+            with opener(tmp, "wb") as fp:
+                pickle.dump(self, fp)
+            os.replace(tmp, target)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def load(path: os.PathLike | str) -> "RunArtifact":
+        """
+        Read an artifact written by :meth:`dump`.
+
+        :param path: The artifact file. The codec is detected from its magic
+            bytes, so compressed and plain artifacts are read transparently.
+        :returns: The artifact.
+        """
+        with open(path, "rb") as fp:
+            header = fp.read(2)
+        opener = gzip.open if header.startswith(_GZIP_MAGIC) else open
+        with opener(path, "rb") as fp:
+            return pickle.load(fp)
+
+
+class Suite:
+    """
+    The merge of every run's artifact.
+
+    :ivar runs: The per-run records, failing runs first.
+    :ivar catalog: Feature id to name, unioned over all runs.
+    :ivar tree: The merged call tree, or ``None`` when no run built one.
+    """
+
+    def __init__(
+        self,
+        runs: List[RunArtifact],
+        catalog: Dict[int, str],
+        tree: Optional[TreeNode] = None,
+    ):
+        self.runs = runs
+        self.catalog = catalog
+        self.tree = tree
+
+    @staticmethod
+    def merge(artifacts: Iterable[RunArtifact]) -> "Suite":
+        """
+        Merge run artifacts into one suite.
+
+        :param artifacts: The artifacts, in any order.
+        :returns: The merged suite.
+
+        Failing runs are merged first and kept first. Tree consumers prune
+        passing runs against the failing footprint -- a function no failing run
+        ever reached cannot discriminate -- and that only works if the failing
+        side of the tree exists before the passing runs are folded in. Ordering
+        here means the collector does not need to know which tests fail before
+        it runs them.
+        """
+        ordered = sorted(
+            artifacts, key=lambda a: 0 if a.result == TestResult.FAILING else 1
+        )
+        catalog: Dict[int, str] = dict()
+        tree: Optional[TreeNode] = None
+        for artifact in ordered:
+            catalog.update(artifact.catalog)
+            if artifact.tree is not None:
+                if tree is None:
+                    tree = TreeNode(artifact.tree.name)
+                tree.merge(artifact.tree)
+        return Suite(ordered, catalog, tree)
+
+    def name(self, feature_id: int) -> str:
+        """
+        :param feature_id: A feature id.
+        :returns: The feature's name, or its id as a string when unknown.
+        """
+        return self.catalog.get(feature_id, str(feature_id))
+
+    def counts(self) -> Dict[int, Dict[str, int]]:
+        """
+        Aggregate the per-run records into spectrum counts.
+
+        :returns: Feature id to ``{"ef", "nf", "ep", "np"}``: runs where the
+            feature held (``e``) or did not (``n``), failing (``f``) or passing
+            (``p``). These are the four numbers every similarity coefficient in
+            :mod:`sflkit.analysis.spectra` is defined over.
+        """
+        counts: Dict[int, Dict[str, int]] = {
+            feature_id: {"ef": 0, "nf": 0, "ep": 0, "np": 0}
+            for feature_id in self.catalog
+        }
+        for artifact in self.runs:
+            if artifact.result == TestResult.FAILING:
+                hit, missed = "ef", "nf"
+            elif artifact.result == TestResult.PASSING:
+                hit, missed = "ep", "np"
+            else:
+                continue
+            for feature_id in counts:
+                value = artifact.features.get(feature_id, FeatureValue.UNDEFINED.value)
+                counts[feature_id][
+                    hit if value == FeatureValue.TRUE.value else missed
+                ] += 1
+        return counts
+
+
+class OnlineSession:
+    """
+    Ties a tracer to the listeners that consume its events.
+
+    :ivar index: Location index for the subject.
+    :ivar builder: The feature (and optionally tree) builder.
+    :ivar spectra: Spectrum listener, when spectra were requested.
+    :ivar listeners: Everything fed from the run.
+    :ivar tracer: The runtime backend.
+    """
+
+    def __init__(
+        self,
+        mapping: Optional[EventMapping] = None,
+        root: Optional[os.PathLike | str] = None,
+        thread_support: bool = False,
+        tree: bool = True,
+        spectra: bool = False,
+        types: Optional[Iterable[AnalysisType]] = None,
+        prefer_monitoring: bool = True,
+        index: Optional[LocationIndex] = None,
+    ):
+        """
+        :param mapping: Event mapping produced by instrumentation. Not needed
+            when *index* is given.
+        :param root: Directory the mapping's file names are relative to.
+        :param thread_support: Trace threads and key scopes by thread id.
+        :param tree: Build a mergeable call tree alongside the feature vector.
+        :param spectra: Also build spectra and predicates in this process,
+            which is only useful when one process runs several tests.
+        :param types: Analysis types for the spectrum listener.
+        :param prefer_monitoring: Force the portable backend when ``False``.
+        :param index: A location index to reuse. Building one parses every
+            mapped source file, so a process running many tests builds it once
+            and hands it to each run's session.
+        """
+        if index is None:
+            if mapping is None or root is None:
+                raise ValueError("Either an index or a mapping and root are required")
+            index = LocationIndex(mapping, root)
+        self.index = index
+        self.builder = TreeBuilder() if tree else None
+        self.vectors = BuilderListener(
+            builder=self.builder, thread_support=thread_support
+        )
+        self.spectra = (
+            SpectrumListener(types=types, thread_support=thread_support)
+            if spectra
+            else None
+        )
+        self.listeners = ListenerGroup(self.vectors)
+        if self.spectra is not None:
+            self.listeners.add(self.spectra)
+        self.tracer: Tracer = get_tracer(
+            self.index,
+            self.listeners,
+            thread_support=thread_support,
+            prefer_monitoring=prefer_monitoring,
+        )
+        self._run: Optional[EventFile] = None
+        self._name: str = ""
+
+    def start(self, name: str, failing: Optional[bool] = None, run_id: int = 0) -> None:
+        """
+        Begin tracing a run.
+
+        :param name: Name of the run, usually the test id.
+        :param failing: Whether the run fails. ``None`` records it as undefined,
+            which is the honest value while the verdict is still unknown.
+        :param run_id: Identifier, only needs to be unique within the process.
+        """
+        self._name = name
+        # EventFile is the analysis layer's per-run key everywhere; it is never
+        # opened here, so reusing it costs nothing and avoids a parallel type.
+        self._run = EventFile(Path(name), run_id, None, failing)
+        self.listeners.start(self._run)
+        self.tracer.start()
+
+    def stop(self) -> None:
+        """Stop tracing and finish the run."""
+        self.tracer.stop()
+        self.listeners.stop()
+
+    def artifact(self) -> RunArtifact:
+        """
+        :returns: What this run contributes to the analysis.
+        :raises ValueError: When no run has been traced yet.
+        """
+        if self._run is None:
+            raise ValueError("No run has been traced")
+        vector = self.vectors.builder.feature_vectors[self._run]
+        features = dict()
+        catalog = dict()
+        for feature, value in vector.get_features().items():
+            features[feature.id] = value.value
+            catalog[feature.id] = feature.name
+        if self.builder is not None:
+            catalog.update(self.builder.catalog)
+        return RunArtifact(
+            self._name,
+            vector.result,
+            features,
+            catalog,
+            self.builder.root if self.builder is not None else None,
+        )
+
+
+@contextmanager
+def trace(
+    mapping: EventMapping,
+    root: os.PathLike | str,
+    name: str = "run",
+    failing: Optional[bool] = None,
+    thread_support: bool = False,
+    tree: bool = True,
+    spectra: bool = False,
+    types: Optional[Iterable[AnalysisType]] = None,
+    prefer_monitoring: bool = True,
+):
+    """
+    Trace everything executed in the block.
+
+    :param mapping: Event mapping produced by instrumentation.
+    :param root: Directory the mapping's file names are relative to.
+    :param name: Name of the run.
+    :param failing: Whether the run fails, when already known.
+    :param thread_support: Trace threads and key scopes by thread id.
+    :param tree: Build a mergeable call tree.
+    :param spectra: Also build spectra and predicates.
+    :param types: Analysis types for the spectrum listener.
+    :param prefer_monitoring: Force the portable backend when ``False``.
+    :yields: The :class:`OnlineSession`, so the caller can take its artifact.
+    """
+    session = OnlineSession(
+        mapping,
+        root,
+        thread_support=thread_support,
+        tree=tree,
+        spectra=spectra,
+        types=types,
+        prefer_monitoring=prefer_monitoring,
+    )
+    session.start(name, failing=failing)
+    try:
+        yield session
+    finally:
+        session.stop()

--- a/src/sflkit/online/structure.py
+++ b/src/sflkit/online/structure.py
@@ -1,0 +1,210 @@
+"""
+Source structure the tracer needs but an event mapping does not record.
+
+Branch events are the reason this module exists. Instrumentation injects a
+branch probe as the *first statement of each body*, but records it against the
+line of the ``if`` that owns it, so both probes of a branch share one location.
+In an instrumented run that is unambiguous, because only the probe in the taken
+body executes. A tracer watching the original source sees only "line 6 ran" and
+cannot tell the two apart.
+
+What does distinguish them is where execution goes next: entering the then-body
+means the next line executed in that frame lies inside it. The bodies' line
+ranges are not in the mapping, but they are in the source, and the source is
+right there -- the tracer is watching it run. Parsing each mapped file once at
+setup therefore recovers exactly the missing bit.
+"""
+
+import ast
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+#: Nodes that produce a two-sided branch: the body, and everything else.
+_BRANCHING = (ast.If, ast.While, ast.For, ast.AsyncFor)
+
+
+class Span:
+    """
+    An inclusive range of source lines.
+
+    :ivar start: First line.
+    :ivar end: Last line.
+    """
+
+    __slots__ = ("start", "end")
+
+    def __init__(self, start: int, end: int):
+        self.start = start
+        self.end = end
+
+    def __contains__(self, line: int) -> bool:
+        return self.start <= line <= self.end
+
+    def __repr__(self):
+        return f"Span({self.start}, {self.end})"
+
+
+class BranchSite:
+    """
+    A branching statement, as the tracer needs to see it.
+
+    :ivar line: Line of the statement's head, which is where both of its branch
+        templates are recorded.
+    :ivar then: Span of the body taken when the test holds.
+    :ivar orelse: Span of the ``else`` body, or ``None`` when there is none.
+        A missing ``else`` is still a branch: instrumentation synthesizes one to
+        put its probe in.
+    :ivar loop: Whether the statement repeats. A loop head runs once per
+        iteration, but the probes hoisted in front of the loop run once, so the
+        two groups have to be told apart.
+    :ivar targets: Names the loop binds each iteration. Their def and len
+        probes sit on the head line but belong to the body.
+    """
+
+    __slots__ = ("line", "then", "orelse", "loop", "targets")
+
+    def __init__(
+        self,
+        line: int,
+        then: Span,
+        orelse: Optional[Span],
+        loop: bool = False,
+        targets: Optional[frozenset] = None,
+    ):
+        self.line = line
+        self.then = then
+        self.orelse = orelse
+        self.loop = loop
+        self.targets = targets or frozenset()
+
+    def owns(self, line: int) -> bool:
+        """
+        :param line: A line number.
+        :returns: Whether *line* belongs to this statement, head or body. Used
+            to notice that a loop was left, including by ``break``, which skips
+            the head entirely.
+        """
+        return line == self.line or line in self.then
+
+    def taken(self, line: int) -> bool:
+        """
+        :param line: The next line executed in the frame.
+        :returns: Whether the body was entered. Anything that is not inside the
+            body means it was not: either the ``else`` ran, or the statement was
+            skipped entirely, and both are the sibling branch.
+        """
+        return line in self.then
+
+    def __repr__(self):
+        return f"BranchSite({self.line}, then={self.then}, orelse={self.orelse})"
+
+
+class TrySite:
+    """
+    A ``try`` statement.
+
+    Its branch probe is placed at the *end* of the body rather than the start,
+    because what it records is "the body completed without raising". It
+    therefore fires when execution leaves the body normally.
+
+    :ivar line: Line of the ``try``.
+    :ivar body: Span of the protected body.
+    :ivar completes: Whether the body can finish by running off its end. When
+        it ends in ``return``, ``raise``, ``break`` or ``continue`` the probe
+        instrumentation appends after it is unreachable, so no event is due.
+    """
+
+    __slots__ = ("line", "body", "completes")
+
+    def __init__(self, line: int, body: Span, completes: bool = True):
+        self.line = line
+        self.body = body
+        self.completes = completes
+
+    def __repr__(self):
+        return f"TrySite({self.line}, body={self.body})"
+
+
+def _span(statements: List[ast.stmt]) -> Span:
+    """
+    :param statements: A non-empty statement list.
+    :returns: The span the list covers.
+    """
+    first = statements[0]
+    last = statements[-1]
+    return Span(first.lineno, getattr(last, "end_lineno", None) or last.lineno)
+
+
+def _targets(node: ast.stmt) -> frozenset:
+    """
+    :param node: A loop.
+    :returns: The names it binds each iteration. ``while`` binds nothing.
+    """
+    target = getattr(node, "target", None)
+    if target is None:
+        return frozenset()
+    return frozenset(
+        child.id for child in ast.walk(target) if isinstance(child, ast.Name)
+    )
+
+
+class SourceStructure:
+    """
+    Branch and ``try`` structure of one subject, keyed by file and line.
+
+    :ivar branches: ``(file, line)`` to the branching statement there.
+    :ivar tries: ``(file, line)`` to the ``try`` statement there.
+    """
+
+    def __init__(self):
+        self.branches: Dict[Tuple[str, int], BranchSite] = dict()
+        self.tries: Dict[Tuple[str, int], TrySite] = dict()
+
+    def add_file(self, name: str, path: Path) -> None:
+        """
+        Parse *path* and record its branching statements under *name*.
+
+        :param name: The mapping's name for the file.
+        :param path: Where to read it from. A file that cannot be read or parsed
+            is skipped: the tracer then falls back to emitting no branch events
+            for it, which loses data but never invents any.
+        """
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, SyntaxError, ValueError):
+            return
+        for node in ast.walk(tree):
+            if isinstance(node, _BRANCHING) and node.body:
+                loop = not isinstance(node, ast.If)
+                self.branches[(name, node.lineno)] = BranchSite(
+                    node.lineno,
+                    _span(node.body),
+                    _span(node.orelse) if node.orelse else None,
+                    loop,
+                    _targets(node) if loop else None,
+                )
+            elif isinstance(node, ast.Try) and node.body:
+                self.tries[(name, node.lineno)] = TrySite(
+                    node.lineno,
+                    _span(node.body),
+                    not isinstance(
+                        node.body[-1],
+                        (ast.Return, ast.Raise, ast.Break, ast.Continue),
+                    ),
+                )
+
+    def branch(self, file: str, line: int) -> Optional[BranchSite]:
+        """
+        :param file: Mapping-relative file name.
+        :param line: Line of the branching statement.
+        :returns: The site, or ``None``.
+        """
+        return self.branches.get((file, line))
+
+    def try_(self, file: str, line: int) -> Optional[TrySite]:
+        """
+        :param file: Mapping-relative file name.
+        :param line: Line of the ``try``.
+        :returns: The site, or ``None``.
+        """
+        return self.tries.get((file, line))

--- a/src/sflkit/online/tracer.py
+++ b/src/sflkit/online/tracer.py
@@ -1,0 +1,1238 @@
+"""
+Runtime tracers that produce sflkit events without writing a trace.
+
+Source instrumentation rewrites the program so that probe calls emit events.
+A tracer instead leaves the program untouched and reconstructs the same events
+from CPython's own monitoring hooks plus the static event mapping that
+instrumentation already produces.
+
+That trade buys three things. The run needs no instrumented copy of the
+subject, so what executes is the program as shipped. Values are read from the
+frame, so scoping is the interpreter's own rather than a scope reconstructed
+from the event stream. And events go straight to listeners, so a run costs no
+trace file at all.
+
+Two backends materialize events identically:
+
+* :class:`MonitoringTracer` uses :mod:`sys.monitoring` (PEP 669, Python 3.12+).
+  It is the fast path: event types are opted into individually, and a location
+  with nothing mapped to it is permanently disabled after its first hit, so the
+  interpreter stops calling back for it. It observes every thread.
+* :class:`SysTraceTracer` uses :func:`sys.settrace` and works on every version
+  sflkit supports, at the cost of a Python callback per executed line. It is
+  installed for threads started while tracing via :func:`threading.settrace`.
+
+:func:`get_tracer` picks the best available backend.
+
+Known limit, both backends: ``CONDITION`` and ``CONDITION_VALUE`` carry the
+runtime truth value of a source expression. Recovering that from outside the
+program would mean re-evaluating the expression in the frame, which can run
+subject code a second time -- exactly the perturbation a probe must never
+cause. The tracer therefore does not emit them; instrument the subject when
+those types are required. Everything else is materialized in full.
+"""
+
+import abc
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from sflkitlib.events import EventType
+from sflkitlib.events.event import Event
+
+from sflkit.events.mapping import EventMapping
+from sflkit.logger import LOGGER
+from sflkit.online.listener import EventListener
+from sflkit.online.structure import BranchSite, SourceStructure, TrySite
+
+#: Types whose value is recorded verbatim; anything else is recorded by type
+#: name only. Mirrors ``sflkitlib.lib.add_def_event`` so that an online event
+#: and its instrumented counterpart carry identical payloads.
+_SCALAR_TYPES = (int, float, complex, str, bytes, bytearray, bool)
+
+#: Function-boundary types, indexed per function rather than per line.
+_FUNCTION_TYPES = frozenset(
+    {EventType.FUNCTION_ENTER, EventType.FUNCTION_EXIT, EventType.FUNCTION_ERROR}
+)
+
+#: Event types the tracer can materialize. CONDITION/CONDITION_VALUE are absent
+#: by design; see the module docstring.
+SUPPORTED_EVENT_TYPES = frozenset(
+    {
+        EventType.LINE,
+        EventType.BRANCH,
+        EventType.DEF,
+        EventType.USE,
+        EventType.LEN,
+        EventType.LOOP_BEGIN,
+        EventType.LOOP_HIT,
+        EventType.LOOP_END,
+    }
+    | _FUNCTION_TYPES
+)
+
+
+def env_int(name: str, default: int) -> int:
+    """
+    Read an integer budget from the environment.
+
+    :param name: Environment variable to read.
+    :param default: Value to use when it is unset or unreadable.
+    :returns: The budget.
+    """
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def value_and_type(value: Any, max_value_bytes: int = 0) -> Tuple[Any, str]:
+    """
+    Split *value* into the payload and type name an event should carry.
+
+    :param value: The runtime value.
+    :param max_value_bytes: Longest ``str``/``bytes`` value to keep whole;
+        ``0`` keeps everything. Mirrors ``EVENTS_MAX_VALUE_BYTES``.
+    :returns: ``(payload, type_name)``. Scalars and ``None`` keep their value;
+        anything else is recorded as ``None`` with a qualified type name, so a
+        trace never retains a reference to an arbitrary object.
+
+    Oversized strings are cut to their prefix, as ``sflkitlib.lib._cap_value``
+    does, because a definition of a multi-megabyte buffer would otherwise carry
+    that whole buffer. The type name is that of the original value: truncating
+    what is recorded must not change what the value is reported to be.
+    """
+    type_ = type(value)
+    if type_ in _SCALAR_TYPES or value is None:
+        if max_value_bytes > 0:
+            # Only str and bytes have a length worth capping; a number has no
+            # prefix to keep, and asking for its length raises.
+            if type_ is str and len(value) > max_value_bytes:
+                value = value[:max_value_bytes]
+            elif type_ in (bytes, bytearray) and len(value) > max_value_bytes:
+                value = bytes(value[:max_value_bytes])
+        return value, type_.__name__
+    return None, f"{type_.__module__}.{type_.__name__}"
+
+
+class ThreadIds:
+    """
+    Assigns compact, run-local ids to threads.
+
+    :class:`~sflkit.model.parallel.ParallelModel` keys one variable scope per
+    thread id, so ids only need to be distinct within a run. Compact counting
+    ids reproduce what ``sflkitlib.lib`` writes into instrumented traces, which
+    keeps online and offline events comparable.
+
+    :ivar enabled: When ``False`` every lookup returns ``None``, which is how a
+        single-threaded run is represented.
+    """
+
+    def __init__(self, enabled: bool = False):
+        """
+        :param enabled: Whether to hand out ids at all.
+        """
+        self.enabled = enabled
+        self._ids: Dict[int, int] = dict()
+        self._lock = threading.Lock()
+
+    def get(self) -> Optional[int]:
+        """
+        :returns: The calling thread's compact id, or ``None`` when thread
+            support is off.
+        """
+        if not self.enabled:
+            return None
+        key = threading.get_ident()
+        try:
+            return self._ids[key]
+        except KeyError:
+            with self._lock:
+                if key not in self._ids:
+                    self._ids[key] = len(self._ids)
+                return self._ids[key]
+
+
+class FunctionTemplates:
+    """
+    The function-boundary templates of one function.
+
+    :ivar enter: Template for entering the function, if instrumented.
+    :ivar exits: Exit templates keyed by the line they were injected at. A
+        function has one per ``return`` plus, usually, a fall-through exit.
+    :ivar last_exit: Fall-through exit, used when a return happens at a line
+        that carries no exit template of its own.
+    :ivar error: Template for leaving through an exception.
+    :ivar parameters: Def templates for the function's parameters. They sit on
+        the ``def`` line, which never executes inside the function's own frame,
+        so they are emitted on entry instead -- the moment the parameters are
+        bound.
+    :ivar line: Line the enter template sits on, used to tell same-named
+        functions in one file apart.
+    """
+
+    __slots__ = ("enter", "exits", "last_exit", "error", "parameters", "line")
+
+    def __init__(self):
+        self.enter: Optional[Event] = None
+        self.exits: Dict[int, Event] = dict()
+        self.last_exit: Optional[Event] = None
+        self.error: Optional[Event] = None
+        self.parameters: List[Event] = list()
+        self.line: int = 0
+
+
+class Location:
+    """
+    Everything mapped to one ``(file, line)``, pre-sorted by how it is emitted.
+
+    Splitting this once at setup keeps the hot path free of type tests: the
+    line hook emits :attr:`templates`, and only touches the branch fields when
+    they are actually populated.
+
+    :ivar templates: Templates emitted as soon as the line runs. For a loop
+        head these are the probes hoisted in front of the loop, so they are
+        emitted on arrival only, not once per iteration.
+    :ivar on_body: Templates due once the body is known to have been entered:
+        the taken branch, and for a loop its hit and the binding of its target.
+    :ivar on_exit: Templates due when the body was not entered: the other
+        branch. For a loop this is its ``else``, which a ``break`` skips.
+    :ivar on_finally: Templates due whenever a loop is left, however it is
+        left. Instrumentation puts the loop-end probe in a ``finally``, so a
+        ``break`` or a ``return`` from inside the body still records it.
+    :ivar key: The ``(file, line)`` this record is filed under.
+    :ivar site: Source structure deciding between the two.
+    :ivar completed: Branch template recording that a ``try`` body finished
+        without raising, or ``None``.
+    :ivar try_site: Source structure for that ``try``.
+    """
+
+    __slots__ = (
+        "templates",
+        "on_body",
+        "on_exit",
+        "on_finally",
+        "site",
+        "completed",
+        "try_site",
+        "key",
+    )
+
+    def __init__(self, key: Tuple[str, int] = ("", 0)):
+        self.key = key
+        self.templates: List[Event] = list()
+        self.on_body: List[Event] = list()
+        self.on_exit: List[Event] = list()
+        self.on_finally: List[Event] = list()
+        self.site: Optional[BranchSite] = None
+        self.completed: Optional[Event] = None
+        self.try_site: Optional[TrySite] = None
+
+
+class LocationIndex:
+    """
+    Turns an :class:`~sflkit.events.mapping.EventMapping` into runtime lookups.
+
+    Instrumentation already decided which events exist and where; the tracer
+    only recognizes the location and fills in the runtime values. The index
+    also answers the question the fast backend asks constantly -- "is anything
+    mapped here at all?" -- so uninteresting locations can be disabled for good.
+
+    :ivar files: Mapping-relative paths of files carrying at least one event.
+    :ivar skipped: Event types in the mapping the tracer cannot materialize.
+    """
+
+    def __init__(self, mapping: EventMapping, root: os.PathLike | str):
+        """
+        :param mapping: The mapping produced by instrumentation.
+        :param root: Directory the mapping's file names are relative to, used
+            to translate a frame's ``co_filename`` back into the mapping's name.
+        """
+        self.root = Path(root).resolve()
+        self.files: Set[str] = set()
+        self.skipped: Set[EventType] = set()
+        self._by_location: Dict[Tuple[str, int], Location] = dict()
+        self.structure = SourceStructure()
+        self._functions: Dict[Tuple[str, str], List[FunctionTemplates]] = dict()
+        self._resolved: Dict[str, Optional[str]] = dict()
+        for event in sorted(mapping.mapping.values(), key=lambda e: e.event_id):
+            if event.event_type not in SUPPORTED_EVENT_TYPES:
+                self.skipped.add(event.event_type)
+                continue
+            self.files.add(event.file)
+            if event.event_type in _FUNCTION_TYPES:
+                self._add_function_template(event)
+            else:
+                self._location(event.file, event.line).templates.append(event)
+        for templates in self._functions.values():
+            templates.sort(key=lambda t: t.line)
+        for name in self.files:
+            self.structure.add_file(name, self.root / name)
+        self._claim_parameters()
+        self._claim_branches()
+        if self.skipped:
+            LOGGER.info(
+                "Tracer cannot materialize %s; instrument the subject to collect them",
+                ", ".join(sorted(type_.name for type_ in self.skipped)),
+            )
+
+    def _claim_parameters(self) -> None:
+        """
+        Move the def templates on each ``def`` line into their function.
+
+        A parameter's def probe is placed on the line of the ``def`` itself,
+        but that line only ever executes in the *enclosing* frame, when the
+        function object is created. Left in the line index the templates would
+        be looked up in the wrong frame, where the parameter names are not
+        bound, and silently produce nothing.
+        """
+        for candidates in self._functions.values():
+            for templates in candidates:
+                if templates.enter is None:
+                    continue
+                key = (templates.enter.file, templates.enter.line)
+                location = self._by_location.get(key)
+                if location is None:
+                    continue
+                remaining = []
+                for template in location.templates:
+                    if template.event_type in (
+                        EventType.DEF,
+                        EventType.USE,
+                        EventType.LEN,
+                    ):
+                        templates.parameters.append(template)
+                    else:
+                        remaining.append(template)
+                location.templates = remaining
+                templates.parameters.sort(key=lambda e: e.event_id)
+
+    def _location(self, file: str, line: int) -> Location:
+        """
+        :param file: Mapping-relative file name.
+        :param line: Line number.
+        :returns: The location record, created on first use.
+        """
+        key = (file, line)
+        location = self._by_location.get(key)
+        if location is None:
+            location = Location(key)
+            self._by_location[key] = location
+        return location
+
+    def _claim_branches(self) -> None:
+        """
+        Split each branching line into what is emitted when, and tie it to the
+        statement it belongs to.
+
+        Instrumentation records every probe of a branching statement against
+        the head line, but it injects them at three different points: in front
+        of the statement, inside the body, and after it. In an instrumented run
+        that is unambiguous because only the reached probes execute. A tracer
+        sees one line and must reconstruct the split, which is what this does,
+        once, at setup.
+
+        A branch template with no matching statement -- an exception handler's,
+        whose line runs on its own -- keeps being emitted directly.
+        """
+        for (file, line), location in self._by_location.items():
+            branches = [
+                template
+                for template in location.templates
+                if template.event_type is EventType.BRANCH
+            ]
+            loops = [
+                template
+                for template in location.templates
+                if template.event_type
+                in (EventType.LOOP_BEGIN, EventType.LOOP_HIT, EventType.LOOP_END)
+            ]
+            if not branches and not loops:
+                continue
+            site = self.structure.branch(file, line)
+            if site is None:
+                if len(branches) == 1:
+                    try_site = self.structure.try_(file, line)
+                    if try_site is not None:
+                        location.completed = branches[0]
+                        location.try_site = try_site
+                        location.templates.remove(branches[0])
+                continue
+            location.site = site
+            remaining: List[Event] = []
+            # Lower id is the then-branch: instrumentation walks the then body
+            # before the else body.
+            branches.sort(key=lambda e: e.event_id)
+            for template in location.templates:
+                type_ = template.event_type
+                if type_ is EventType.BRANCH:
+                    if template is branches[0]:
+                        location.on_body.append(template)
+                    else:
+                        location.on_exit.append(template)
+                elif type_ is EventType.LOOP_HIT:
+                    location.on_body.append(template)
+                elif type_ is EventType.LOOP_END:
+                    location.on_finally.append(template)
+                elif site.loop and getattr(template, "var", None) in site.targets:
+                    # The loop variable is bound once per iteration, inside the
+                    # body, even though its probe is recorded on the head line.
+                    location.on_body.append(template)
+                else:
+                    remaining.append(template)
+            location.templates = remaining
+            location.on_body.sort(key=lambda e: e.event_id)
+            location.on_exit.sort(key=lambda e: e.event_id)
+            location.on_finally.sort(key=lambda e: e.event_id)
+
+    def _add_function_template(self, event: Event) -> None:
+        """
+        File one function-boundary template under its function.
+
+        :param event: A function enter, exit or error template.
+        """
+        key = (event.file, event.function)
+        candidates = self._functions.setdefault(key, [])
+        # Templates of one function share a function_id; instrumentation
+        # assigns a fresh one per function, so it separates same-named
+        # functions (overloads, nested defs, methods) reliably.
+        for templates in candidates:
+            if templates.enter is not None and templates.enter.function_id == (
+                event.function_id
+            ):
+                break
+            if (
+                templates.exits
+                and next(iter(templates.exits.values())).function_id
+                == event.function_id
+            ):
+                break
+            if templates.error is not None and (
+                templates.error.function_id == event.function_id
+            ):
+                break
+        else:
+            templates = FunctionTemplates()
+            candidates.append(templates)
+        if event.event_type is EventType.FUNCTION_ENTER:
+            templates.enter = event
+            templates.line = event.line
+        elif event.event_type is EventType.FUNCTION_EXIT:
+            templates.exits[event.line] = event
+            templates.last_exit = event
+            if not templates.line:
+                templates.line = event.line
+        else:
+            templates.error = event
+            if not templates.line:
+                templates.line = event.line
+
+    def relative(self, filename: str) -> Optional[str]:
+        """
+        Translate a runtime ``co_filename`` into the mapping's file name.
+
+        :param filename: Filename as CPython reports it, absolute or relative.
+        :returns: The mapping's name for that file, or ``None`` when the file
+            carries no events. Cached, because this is asked once per location.
+        """
+        try:
+            return self._resolved[filename]
+        except KeyError:
+            pass
+        resolved: Optional[str] = None
+        if filename in self.files:
+            resolved = filename
+        else:
+            try:
+                candidate = os.path.relpath(Path(filename).resolve(), self.root)
+            except (OSError, ValueError):
+                candidate = None
+            if candidate in self.files:
+                resolved = candidate
+        self._resolved[filename] = resolved
+        return resolved
+
+    def at(self, file: str, line: int) -> Optional[Location]:
+        """
+        :param file: Mapping-relative file name.
+        :param line: Line number.
+        :returns: What is mapped there, or ``None``.
+        """
+        return self._by_location.get((file, line))
+
+    def function(
+        self, file: str, name: str, first_line: int
+    ) -> Optional[FunctionTemplates]:
+        """
+        Find the templates of the function a code object belongs to.
+
+        :param file: Mapping-relative file name.
+        :param name: The code object's name.
+        :param first_line: The code object's first line.
+        :returns: The matching templates, or ``None``.
+
+        Where a file holds several functions of the same name, the one whose
+        probes sit closest below the code object's first line wins: probes are
+        injected inside the body, so the correct function is always the nearest
+        one at or after ``def``.
+        """
+        candidates = self._functions.get((file, name))
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+        best = None
+        for templates in candidates:
+            if templates.line >= first_line and (
+                best is None or templates.line < best.line
+            ):
+                best = templates
+        return best or candidates[0]
+
+    def has_events(self, file: str) -> bool:
+        """
+        :param file: Mapping-relative file name.
+        :returns: Whether the file carries any event at all.
+        """
+        return file in self.files
+
+    def __len__(self) -> int:
+        return sum(
+            len(location.templates)
+            + len(location.on_body)
+            + len(location.on_exit)
+            + len(location.on_finally)
+            + (1 if location.completed else 0)
+            for location in self._by_location.values()
+        ) + sum(len(candidates) for candidates in self._functions.values())
+
+
+class Tracer(abc.ABC):
+    """
+    Shared materialization for the runtime backends.
+
+    A backend only has to recognize interpreter callbacks and call
+    :meth:`_line`, :meth:`_enter`, :meth:`_exit` and :meth:`_error`; turning a
+    template plus a frame into an event happens here, once.
+
+    :ivar index: Location index for the subject.
+    :ivar listener: Where materialized events go.
+    :ivar thread_ids: Compact thread-id source.
+    """
+
+    def __init__(
+        self,
+        index: LocationIndex,
+        listener: EventListener,
+        thread_support: bool = False,
+    ):
+        """
+        :param index: Location index for the subject.
+        :param listener: Listener or
+            :class:`~sflkit.online.listener.ListenerGroup` to feed.
+        :param thread_support: Stamp events with a compact thread id.
+        """
+        self.index = index
+        self.listener = listener
+        self.thread_ids = ThreadIds(thread_support)
+        self._local = threading.local()
+        self.running = False
+        # The same budgets the instrumented runtime applies, read from the same
+        # environment variables with the same defaults. Without them the two
+        # collection paths disagree on any loop that runs more than twice: the
+        # runtime stops recording hits and the tracer would keep going, so the
+        # online spectra would be strictly richer than the offline ones and the
+        # two would no longer be comparable.
+        self.max_loop_hits = env_int("EVENTS_MAX_LOOP_HITS", 2)
+        self.max_value_bytes = env_int("EVENTS_MAX_VALUE_BYTES", 1024)
+        #: Hits recorded per thread per loop, keyed as the runtime keys them.
+        self._loop_hits: Dict[Tuple[Optional[int], int], int] = dict()
+
+    @property
+    def _pending(self) -> Dict[Any, List[Event]]:
+        """
+        Def templates parked per frame, for the calling thread only.
+
+        Instrumentation places a def probe *after* the assignment, but a line
+        hook fires *before* the line runs, so at hook time the binding does not
+        exist yet. The def is parked and materialized at the next hook for the
+        same frame, which is the first moment the value is observable. Parking
+        is per frame, not per thread, because ``x = f()`` parks in the caller
+        while ``f`` runs in a frame of its own; and the state is thread-local,
+        so concurrent threads never contend for it.
+        """
+        pending = getattr(self._local, "pending", None)
+        if pending is None:
+            pending = dict()
+            self._local.pending = pending
+        return pending
+
+    @property
+    def _parked_branches(self) -> Dict[Any, "Location"]:
+        """
+        Branch decisions waiting on the next line, per frame.
+
+        Which side of a branch ran is only knowable once execution has moved
+        on, so the decision is parked at the branching line and settled at the
+        next line in the same frame -- or, if there is none, when the frame
+        returns, which means the body was never entered.
+        """
+        parked = getattr(self._local, "branches", None)
+        if parked is None:
+            parked = dict()
+            self._local.branches = parked
+        return parked
+
+    @property
+    def _active_loops(self) -> Dict[Any, Dict[Tuple[str, int], "Location"]]:
+        """Loops currently running, per frame, so a ``break`` is still noticed."""
+        active = getattr(self._local, "loops", None)
+        if active is None:
+            active = dict()
+            self._local.loops = active
+        return active
+
+    @property
+    def _parked_tries(self) -> Dict[Any, List["Location"]]:
+        """``try`` bodies currently executing, per frame."""
+        parked = getattr(self._local, "tries", None)
+        if parked is None:
+            parked = dict()
+            self._local.tries = parked
+        return parked
+
+    @abc.abstractmethod
+    def start(self) -> None:
+        """Install the backend's hooks."""
+
+    @abc.abstractmethod
+    def stop(self) -> None:
+        """Remove the backend's hooks."""
+
+    def arm(self, code) -> None:
+        """
+        Watch *code* even though its call was not observed.
+
+        Only meaningful for backends that monitor per code object.
+
+        :param code: The code object to watch.
+        """
+
+    def __enter__(self) -> "Tracer":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+
+    def _emit(self, event: Optional[Event]) -> None:
+        """
+        Hand one event to the listener, never letting a failure reach the
+        program under test.
+
+        :param event: The event, or ``None`` when it could not be materialized.
+        """
+        if event is None:
+            return
+        try:
+            self.listener.event(event)
+        except Exception:
+            # A tracer must not change what the program does, so a broken
+            # listener costs events rather than raising inside the subject.
+            LOGGER.exception("Listener failed on %r", event)
+
+    def _flush(self, frame: Any) -> None:
+        """
+        Materialize the def events parked for *frame*.
+
+        :param frame: The frame whose parked defs are now observable.
+        """
+        pending = self._pending.pop(frame, None)
+        if not pending:
+            return
+        thread_id = self.thread_ids.get()
+        for template in pending:
+            self._emit(self._def_event(template, frame, thread_id))
+
+    def _line(self, frame: Any, file: str, line: int) -> None:
+        """
+        Handle one line about to execute.
+
+        :param frame: The executing frame.
+        :param file: Mapping-relative file name.
+        :param line: The line number.
+        """
+        self._flush(frame)
+        self._settle_branch(frame, line)
+        self._settle_loops(frame, line)
+        self._settle_tries(frame, line)
+        location = self.index.at(file, line)
+        if location is None:
+            return
+        thread_id = self.thread_ids.get()
+        site = location.site
+        arriving = True
+        if site is not None and site.loop:
+            active = self._active_loops.setdefault(frame, dict())
+            arriving = location.key not in active
+            active[location.key] = location
+        if arriving:
+            # A loop head runs once per iteration, but what is mapped to it
+            # outside the body -- the loop-begin probe, the line, the uses in
+            # the iterable -- was hoisted in front of the loop and runs once.
+            self._emit_templates(location.templates, frame, thread_id, park=True)
+        if site is not None:
+            self._parked_branches[frame] = location
+        if location.completed is not None:
+            self._parked_tries.setdefault(frame, []).append(location)
+
+    def _emit_templates(
+        self, templates: List[Event], frame: Any, thread_id, park: bool
+    ) -> None:
+        """
+        Materialize and emit *templates* against *frame*.
+
+        :param frame: The executing frame.
+        :param thread_id: Compact id of the current thread.
+        :param park: Whether def templates are parked for the next hook. They
+            are, for a line about to run; they are not for the group settled
+            once a loop body has been entered, because the loop variable is
+            already bound by then.
+        """
+        for template in templates:
+            type_ = template.event_type
+            if type_ is EventType.DEF:
+                if park:
+                    self._pending.setdefault(frame, []).append(template)
+                else:
+                    self._emit(self._def_event(template, frame, thread_id))
+            elif type_ is EventType.USE:
+                self._emit(self._use_event(template, frame, thread_id))
+            elif type_ is EventType.LEN:
+                self._emit(self._len_event(template, frame, thread_id))
+            elif type_ is EventType.LOOP_HIT:
+                if self._record_loop_hit(template, thread_id):
+                    self._emit(template.instantiate(thread_id))
+            else:
+                self._emit(template.instantiate(thread_id))
+
+    def _record_loop_hit(self, template: Event, thread_id) -> bool:
+        """
+        Count one hit of a loop and say whether it is still worth recording.
+
+        :param template: The loop-hit template.
+        :param thread_id: The thread the hit happened on.
+        :returns: Whether to emit the event.
+
+        Mirrors ``sflkitlib.lib.add_loop_hit_event``: sflkit distinguishes only
+        never, once and more-than-once, so hits beyond the budget carry no
+        information. The count is keyed by thread and hit event, exactly as the
+        runtime keys it, which means it is not reset when the loop is re-entered
+        -- matching the runtime matters more here than being tidy, because the
+        two have to produce the same events.
+        """
+        if self.max_loop_hits <= 0:
+            return True
+        key = (thread_id, template.event_id)
+        hits = self._loop_hits.get(key, 0) + 1
+        self._loop_hits[key] = hits
+        return hits <= self.max_loop_hits
+
+    def _settle_loops(self, frame: Any, line: int) -> None:
+        """
+        Close every loop *frame* has left without passing its head again.
+
+        :param frame: The executing frame.
+        :param line: The line now running.
+
+        This is what a ``break`` looks like from outside: control leaves the
+        body without the head ever running again, so the loop's end is only
+        detectable by noticing that execution is no longer inside it.
+        """
+        active = self._active_loops.get(frame)
+        if not active:
+            return
+        thread_id = self.thread_ids.get()
+        for key, location in list(active.items()):
+            if not location.site.owns(line):
+                del active[key]
+                self._emit_templates(location.on_finally, frame, thread_id, park=False)
+        if not active:
+            self._active_loops.pop(frame, None)
+
+    def _settle_branch(self, frame: Any, line: int) -> None:
+        """
+        Emit what the parked statement in *frame* turned out to do.
+
+        :param frame: The executing frame.
+        :param line: The line now running, which is what decides it. ``-1``
+            means no line follows, so no body was entered.
+        """
+        location = self._parked_branches.pop(frame, None)
+        if location is None:
+            return
+        thread_id = self.thread_ids.get()
+        if location.site.taken(line):
+            self._emit_templates(location.on_body, frame, thread_id, park=False)
+            return
+        self._emit_templates(location.on_exit, frame, thread_id, park=False)
+        if location.site.loop:
+            active = self._active_loops.get(frame)
+            if active is not None:
+                active.pop(location.key, None)
+            self._emit_templates(location.on_finally, frame, thread_id, park=False)
+
+    def _settle_tries(self, frame: Any, line: int) -> None:
+        """
+        Emit the completion of every ``try`` body *frame* has just left.
+
+        :param frame: The executing frame.
+        :param line: The line now running.
+        """
+        parked = self._parked_tries.get(frame)
+        if not parked:
+            return
+        thread_id = self.thread_ids.get()
+        remaining = []
+        for location in parked:
+            if line in location.try_site.body:
+                remaining.append(location)
+            else:
+                # Leaving the body by running past it means it did not raise.
+                self._emit(location.completed.instantiate(thread_id))
+        if remaining:
+            self._parked_tries[frame] = remaining
+        else:
+            self._parked_tries.pop(frame, None)
+
+    def _settle_tries_on_exit(self, frame: Any) -> None:
+        """
+        Resolve ``try`` bodies still parked when *frame* returns.
+
+        A body that ends in ``return`` never reaches the probe appended after
+        it, so nothing is due; a body that simply runs out at the end of the
+        function does reach it.
+
+        :param frame: The returning frame.
+        """
+        parked = self._parked_tries.pop(frame, None)
+        if not parked:
+            return
+        thread_id = self.thread_ids.get()
+        for location in parked:
+            if location.try_site.completes:
+                self._emit(location.completed.instantiate(thread_id))
+
+    def _enter(self, frame: Any, file: str, name: str, first_line: int) -> None:
+        """
+        Handle a function being entered.
+
+        :param frame: The new frame.
+        :param file: Mapping-relative file name.
+        :param name: The code object's name.
+        :param first_line: The code object's first line.
+        """
+        templates = self.index.function(file, name, first_line)
+        if templates is None or templates.enter is None:
+            return
+        thread_id = self.thread_ids.get()
+        self._emit(templates.enter.instantiate(thread_id))
+        # Parameters are bound before the first line of the body runs, so they
+        # are read now rather than parked like an ordinary def.
+        for template in templates.parameters:
+            if template.event_type is EventType.DEF:
+                self._emit(self._def_event(template, frame, thread_id))
+            elif template.event_type is EventType.USE:
+                self._emit(self._use_event(template, frame, thread_id))
+            else:
+                self._emit(self._len_event(template, frame, thread_id))
+
+    def _exit(
+        self, frame: Any, file: str, name: str, first_line: int, value: Any
+    ) -> None:
+        """
+        Handle a function returning.
+
+        :param frame: The returning frame.
+        :param file: Mapping-relative file name.
+        :param name: The code object's name.
+        :param first_line: The code object's first line.
+        :param value: The returned value.
+        """
+        self._flush(frame)
+        # No further line will run in this frame, so a branch still parked was
+        # one whose body was never entered.
+        self._settle_branch(frame, -1)
+        self._settle_loops(frame, -1)
+        self._settle_tries_on_exit(frame)
+        templates = self.index.function(file, name, first_line)
+        if templates is None:
+            return
+        template = templates.exits.get(frame.f_lineno) or templates.last_exit
+        if template is None:
+            return
+        payload, type_name = value_and_type(value, self.max_value_bytes)
+        self._emit(template.instantiate(payload, type_name, self.thread_ids.get()))
+
+    def _error(self, frame: Any, file: str, name: str, first_line: int) -> None:
+        """
+        Handle a function leaving through an exception.
+
+        :param frame: The unwinding frame.
+        :param file: Mapping-relative file name.
+        :param name: The code object's name.
+        :param first_line: The code object's first line.
+        """
+        # Nothing parked in a frame that is being torn down is observable: the
+        # probes instrumentation would have run are all past the raise.
+        self._pending.pop(frame, None)
+        self._parked_branches.pop(frame, None)
+        self._parked_tries.pop(frame, None)
+        # The loop-end probe sits in a finally, so it runs even while an
+        # exception is unwinding the frame.
+        self._settle_loops(frame, -1)
+        templates = self.index.function(file, name, first_line)
+        if templates is None or templates.error is None:
+            return
+        self._emit(templates.error.instantiate(self.thread_ids.get()))
+
+    def _resolve(self, frame: Any, name: str) -> Tuple[bool, Any]:
+        """
+        Look *name* up in *frame*, following a dotted path.
+
+        :param frame: Frame to resolve against.
+        :param name: A variable name, possibly dotted (``self.x``).
+        :returns: ``(found, value)``. Resolution never raises: any failure
+            reports not-found, because a probe that changes the program is
+            worse than a missing event.
+        """
+        head, *rest = name.split(".")
+        try:
+            local = frame.f_locals
+            if head in local:
+                value = local[head]
+            elif head in frame.f_globals:
+                value = frame.f_globals[head]
+            else:
+                # Builtins are the third and last scope Python itself consults,
+                # and instrumentation records uses of them (`int`, `len`) like
+                # any other name.
+                builtins = frame.f_builtins
+                if head in builtins:
+                    value = builtins[head]
+                else:
+                    return False, None
+            for attribute in rest:
+                value = getattr(value, attribute)
+        except Exception:
+            return False, None
+        return True, value
+
+    def _def_event(self, template: Event, frame: Any, thread_id) -> Optional[Event]:
+        """Materialize a ``DEF`` event, or ``None`` when the name is not bound."""
+        found, value = self._resolve(frame, template.var)
+        if not found:
+            return None
+        payload, type_name = value_and_type(value, self.max_value_bytes)
+        return template.instantiate(id(value), payload, type_name, thread_id)
+
+    def _use_event(self, template: Event, frame: Any, thread_id) -> Optional[Event]:
+        """Materialize a ``USE`` event, or ``None`` when the name is not bound."""
+        found, value = self._resolve(frame, template.var)
+        if not found:
+            return None
+        return template.instantiate(id(value), thread_id)
+
+    def _len_event(self, template: Event, frame: Any, thread_id) -> Optional[Event]:
+        """Materialize a ``LEN`` event, or ``None`` when there is no length."""
+        found, value = self._resolve(frame, template.var)
+        if not found:
+            return None
+        try:
+            length = len(value)
+        except Exception:
+            return None
+        return template.instantiate(id(value), length, thread_id)
+
+
+class MonitoringTracer(Tracer):
+    """
+    Backend built on :mod:`sys.monitoring` (PEP 669), Python 3.12 and newer.
+
+    Cheaper than :func:`sys.settrace` in two ways that matter for tracing a
+    whole test suite. Event types are opted into individually, so nothing pays
+    for events sflkit does not want. And a line in a file that carries no
+    events is disabled the first time it is reached, after which the
+    interpreter stops calling back for it entirely, so library code costs one
+    callback per location for the lifetime of the process rather than one per
+    execution.
+
+    Lines inside mapped files stay enabled even when nothing is mapped to them,
+    because a parked def becomes observable at the next hook for its frame and
+    disabling those lines would delay it.
+
+    Monitoring is process-wide, so every thread is observed without extra work.
+    """
+
+    #: Tool ids tried in order. coverage.py claims ``COVERAGE_ID``, so that one
+    #: is left alone: sflkit's own suite runs under pytest-cov.
+    _TOOL_IDS = (
+        sys.monitoring.PROFILER_ID if hasattr(sys, "monitoring") else 2,
+        sys.monitoring.DEBUGGER_ID if hasattr(sys, "monitoring") else 0,
+        sys.monitoring.OPTIMIZER_ID if hasattr(sys, "monitoring") else 5,
+    )
+
+    def __init__(
+        self,
+        index: LocationIndex,
+        listener: EventListener,
+        thread_support: bool = False,
+    ):
+        super().__init__(index, listener, thread_support=thread_support)
+        self.tool_id: Optional[int] = None
+        #: Code objects already switched to line-level monitoring.
+        self._instrumented: Set[Any] = set()
+
+    @staticmethod
+    def available() -> bool:
+        """:returns: Whether this backend can run on the current interpreter."""
+        return hasattr(sys, "monitoring")
+
+    def _acquire_tool_id(self) -> int:
+        """
+        Claim a monitoring tool id.
+
+        :returns: The claimed id.
+        :raises RuntimeError: When every candidate id is already in use, which
+            means another tool (a debugger, a profiler, coverage) holds them.
+        """
+        for tool_id in self._TOOL_IDS:
+            try:
+                sys.monitoring.use_tool_id(tool_id, "sflkit")
+            except ValueError:
+                continue
+            return tool_id
+        raise RuntimeError(
+            "No free sys.monitoring tool id; another tracing tool is active"
+        )
+
+    def start(self) -> None:
+        if self.running:
+            return
+        events = sys.monitoring.events
+        self.tool_id = self._acquire_tool_id()
+        sys.monitoring.register_callback(self.tool_id, events.LINE, self._on_line)
+        sys.monitoring.register_callback(self.tool_id, events.PY_START, self._on_start)
+        sys.monitoring.register_callback(
+            self.tool_id, events.PY_RETURN, self._on_return
+        )
+        sys.monitoring.register_callback(
+            self.tool_id, events.PY_UNWIND, self._on_unwind
+        )
+        # Only PY_START is global. Enabling LINE globally would instrument
+        # every code object in the process, including sflkit's own analysis
+        # running in this very process, and instrumented bytecode stays slower
+        # even once a location has been disabled. Line events are therefore
+        # switched on per code object, at the first call into a mapped file.
+        sys.monitoring.set_events(self.tool_id, events.PY_START | events.PY_UNWIND)
+        self.running = True
+        # Frames already on the stack will never report a call, so arm them
+        # now: a tracer started from inside subject code (a pytest plugin, a
+        # harness) would otherwise miss the rest of the enclosing frames.
+        frame = sys._getframe(1)
+        while frame is not None:
+            self.arm(frame.f_code)
+            frame = frame.f_back
+
+    def arm(self, code) -> None:
+        """
+        Switch *code* to line-level monitoring straight away.
+
+        Module-level code is already running by the time a tracer starts inside
+        it, so it never reports a call and would otherwise stay unwatched.
+
+        :param code: The code object to watch.
+        """
+        if not self.running or code in self._instrumented:
+            return
+        if self.index.relative(code.co_filename) is None:
+            return
+        self._instrumented.add(code)
+        events = sys.monitoring.events
+        sys.monitoring.set_local_events(
+            self.tool_id, code, events.LINE | events.PY_RETURN
+        )
+
+    def stop(self) -> None:
+        if not self.running:
+            return
+        events = sys.monitoring.events
+        for code in self._instrumented:
+            sys.monitoring.set_local_events(self.tool_id, code, 0)
+        self._instrumented.clear()
+        sys.monitoring.set_events(self.tool_id, 0)
+        for event in (events.LINE, events.PY_START, events.PY_RETURN, events.PY_UNWIND):
+            sys.monitoring.register_callback(self.tool_id, event, None)
+        sys.monitoring.free_tool_id(self.tool_id)
+        self.tool_id = None
+        self.running = False
+
+    def _on_line(self, code, line_number):
+        file = self.index.relative(code.co_filename)
+        if file is None:
+            # Nothing in this file is ever interesting: stop calling us here.
+            return sys.monitoring.DISABLE
+        self._line(sys._getframe(1), file, line_number)
+        return None
+
+    def _on_start(self, code, instruction_offset):
+        file = self.index.relative(code.co_filename)
+        if file is None:
+            return sys.monitoring.DISABLE
+        if code not in self._instrumented:
+            self._instrumented.add(code)
+            events = sys.monitoring.events
+            sys.monitoring.set_local_events(
+                self.tool_id, code, events.LINE | events.PY_RETURN
+            )
+        self._enter(sys._getframe(1), file, code.co_name, code.co_firstlineno)
+        return None
+
+    def _on_return(self, code, instruction_offset, retval):
+        file = self.index.relative(code.co_filename)
+        if file is None:
+            return sys.monitoring.DISABLE
+        self._exit(sys._getframe(1), file, code.co_name, code.co_firstlineno, retval)
+        return None
+
+    def _on_unwind(self, code, instruction_offset, exception):
+        file = self.index.relative(code.co_filename)
+        if file is None:
+            # PY_UNWIND is not a local event, so it cannot be disabled per
+            # location: returning DISABLE here drops the callback entirely.
+            return None
+        self._error(sys._getframe(1), file, code.co_name, code.co_firstlineno)
+        return None
+
+
+class SysTraceTracer(Tracer):
+    """
+    Backend built on :func:`sys.settrace`, for interpreters without
+    :mod:`sys.monitoring`.
+
+    Correct everywhere sflkit runs, but it pays a Python-level callback for
+    every executed line of every traced frame, so it is the fallback rather
+    than the default.
+
+    :func:`threading.settrace` is installed as well, so threads started while
+    tracing are observed. Threads already running when :meth:`start` is called
+    cannot be hooked: CPython offers no way to install a trace function into
+    another live thread.
+    """
+
+    def __init__(
+        self,
+        index: LocationIndex,
+        listener: EventListener,
+        thread_support: bool = False,
+    ):
+        super().__init__(index, listener, thread_support=thread_support)
+        self._previous = None
+
+    @staticmethod
+    def available() -> bool:
+        """:returns: Always ``True``; this backend is the portable one."""
+        return True
+
+    def start(self) -> None:
+        if self.running:
+            return
+        self._previous = sys.gettrace()
+        threading.settrace(self._dispatch)
+        sys.settrace(self._dispatch)
+        self.running = True
+
+    def stop(self) -> None:
+        if not self.running:
+            return
+        sys.settrace(self._previous)
+        threading.settrace(None)
+        self._previous = None
+        self.running = False
+
+    @property
+    def _raised(self) -> Set[Any]:
+        """
+        Frames that have seen an exception, per thread.
+
+        ``settrace`` reports a frame leaving through an exception as a plain
+        ``return`` with ``None``, so the preceding ``exception`` event is what
+        distinguishes an error exit from an ordinary one.
+        """
+        raised = getattr(self._local, "raised", None)
+        if raised is None:
+            raised = set()
+            self._local.raised = raised
+        return raised
+
+    def _dispatch(self, frame, event, arg):
+        """
+        The trace function.
+
+        :param frame: The frame the event belongs to.
+        :param event: ``call``, ``line``, ``return`` or ``exception``.
+        :param arg: Event-specific payload.
+        :returns: Itself for frames worth tracing, ``None`` otherwise, which is
+            how CPython is told to stop tracing a frame.
+        """
+        code = frame.f_code
+        file = self.index.relative(code.co_filename)
+        if file is None:
+            return None
+        if event == "call":
+            self._enter(frame, file, code.co_name, code.co_firstlineno)
+        elif event == "line":
+            self._line(frame, file, frame.f_lineno)
+        elif event == "exception":
+            self._raised.add(id(frame))
+        elif event == "return":
+            if id(frame) in self._raised:
+                self._raised.discard(id(frame))
+                # arg is None for a frame unwound by an exception; a genuine
+                # `return None` would have cleared the flag at the next line.
+                if arg is None:
+                    self._error(frame, file, code.co_name, code.co_firstlineno)
+                    return self._dispatch
+            self._exit(frame, file, code.co_name, code.co_firstlineno, arg)
+        return self._dispatch
+
+    def _line(self, frame: Any, file: str, line: int) -> None:
+        # Reaching a new line means any exception raised earlier in this frame
+        # was handled, so the frame is no longer unwinding.
+        self._raised.discard(id(frame))
+        super()._line(frame, file, line)
+
+
+def get_tracer(
+    index: LocationIndex,
+    listener: EventListener,
+    thread_support: bool = False,
+    prefer_monitoring: bool = True,
+) -> Tracer:
+    """
+    Build the best available tracer for this interpreter.
+
+    :param index: Location index for the subject.
+    :param listener: Listener to feed.
+    :param thread_support: Stamp events with a compact thread id.
+    :param prefer_monitoring: Set to ``False`` to force the portable
+        :func:`sys.settrace` backend, which the tests use to exercise both
+        backends on one interpreter.
+    :returns: A :class:`MonitoringTracer` on Python 3.12+, otherwise a
+        :class:`SysTraceTracer`.
+    """
+    if prefer_monitoring and MonitoringTracer.available():
+        return MonitoringTracer(index, listener, thread_support=thread_support)
+    return SysTraceTracer(index, listener, thread_support=thread_support)

--- a/src/sflkit/online/tree.py
+++ b/src/sflkit/online/tree.py
@@ -1,0 +1,242 @@
+"""
+A call tree that can be merged across processes.
+
+Collectors run inside the test process, so every test produces its own tree and
+the parent has to combine them. Combining is only cheap if a node's
+observations are comparable without shipping the objects they were derived
+from, which is why observations are recorded as ``{feature id: value}`` rather
+than as :class:`~sflkit.features.value.Feature` objects: a feature holds a
+reference to its analysis object, and pickling one drags the whole analysis
+graph across the process boundary.
+
+Feature ids are content digests (see
+:func:`~sflkit.features.value.feature_id`), so the id of a feature is the same
+in every process, and merging two trees is a structural union with observation
+lists concatenated. The catalog kept beside the tree maps ids back to names, so
+nothing is lost by recording ids.
+"""
+
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from sflkitlib.events.event import (
+    FunctionEnterEvent,
+    FunctionErrorEvent,
+    FunctionExitEvent,
+)
+
+from sflkit.events.event_file import EventFile
+from sflkit.features.handler import FeatureBuilder
+from sflkit.features.value import FeatureValue
+
+#: Name of the virtual node every run starts in.
+ROOT = "ROOT"
+
+#: Observations kept per run at each node: the first hit and a sliding last
+#: hit. A hot loop would otherwise let one run dominate a node, while
+#: observations from *different* runs are never evicted, which is what
+#: discrimination between passing and failing runs needs.
+DEFAULT_PER_RUN_CAP = 2
+
+
+class TreeNode:
+    """
+    One function in the call tree, with the observations made at its boundaries.
+
+    :ivar name: Canonical ``file:function:id`` identifier, or :data:`ROOT`.
+    :ivar children: Child nodes keyed by name.
+    :ivar enter: Observations recorded on entry, each ``{feature id: value}``.
+    :ivar exit: Observations recorded on exit.
+    """
+
+    __slots__ = ("name", "children", "enter", "exit")
+
+    def __init__(self, name: str):
+        """
+        :param name: Canonical function identifier.
+        """
+        self.name = name
+        self.children: Dict[str, "TreeNode"] = dict()
+        self.enter: List[Dict[int, int]] = list()
+        self.exit: List[Dict[int, int]] = list()
+
+    def child(self, name: str) -> "TreeNode":
+        """
+        :param name: Canonical identifier of the child.
+        :returns: The child, created on first use.
+        """
+        node = self.children.get(name)
+        if node is None:
+            node = TreeNode(name)
+            self.children[name] = node
+        return node
+
+    def merge(self, other: "TreeNode") -> None:
+        """
+        Fold *other* into this node, recursively.
+
+        :param other: A node built elsewhere, for the same function.
+
+        Merging is append-only: observations from different runs are all
+        evidence and none of them replaces another. Only the structure is
+        deduplicated.
+        """
+        self.enter.extend(other.enter)
+        self.exit.extend(other.exit)
+        for name, node in other.children.items():
+            self.child(name).merge(node)
+
+    def walk(self):
+        """Yield every node in the subtree, this one first."""
+        yield self
+        for child in self.children.values():
+            yield from child.walk()
+
+    def __repr__(self):
+        return f"TreeNode({self.name}, children={len(self.children)})"
+
+
+class TreeBuilder(FeatureBuilder):
+    """
+    Builds feature vectors and a mergeable call tree from one event stream.
+
+    A :class:`~sflkit.features.handler.FeatureBuilder` already sees every event
+    (it registers itself among the analysis objects), so the tree costs one
+    extra dispatch on function boundaries and nothing anywhere else.
+
+    On entering a function a node is opened and the run's feature values are
+    snapshotted; on leaving it they are snapshotted again and the node closes.
+    That is what makes a node's observations comparable across runs: the same
+    program point, the same feature ids, different values.
+
+    :ivar root: The virtual root every run starts in.
+    :ivar catalog: Feature id to feature name, for reading the tree back.
+    :ivar per_run_cap: Observations kept per run at each node.
+    """
+
+    def __init__(self, per_run_cap: int = DEFAULT_PER_RUN_CAP):
+        """
+        :param per_run_cap: Observations to keep per run at each node. See
+            :data:`DEFAULT_PER_RUN_CAP`.
+        """
+        super().__init__()
+        self.root = TreeNode(ROOT)
+        self.catalog: Dict[int, str] = dict()
+        self.per_run_cap = per_run_cap
+        # Per run, per thread: the open call stack. Threads interleave freely,
+        # so a single stack would splice one thread's calls into another's.
+        self._stacks: Dict[EventFile, Dict[Optional[int], List[TreeNode]]] = dict()
+        self._counts: Dict[EventFile, Dict[str, int]] = dict()
+
+    def prepare(self, event_file: EventFile, test_result) -> None:
+        super().prepare(event_file, test_result)
+        # A plain dict, not `defaultdict(lambda: [self.root])`: a lambda is not
+        # picklable, and a builder that has prepared a run has to be able to
+        # cross a process boundary for parallel building.
+        self._stacks[event_file] = dict()
+        self._counts[event_file] = defaultdict(int)
+
+    @staticmethod
+    def function_name(
+        event: FunctionEnterEvent | FunctionExitEvent | FunctionErrorEvent,
+    ) -> str:
+        """
+        :param event: Any function-boundary event.
+        :returns: ``file:function:id``, which stays unique even when a file
+            holds several functions of the same name.
+        """
+        return f"{event.file}:{event.function}:{event.function_id}"
+
+    def hit(self, id_: EventFile, event, *args, **kwargs) -> None:
+        """
+        Record one event, then maintain the tree if it is a function boundary.
+
+        :param id_: The run.
+        :param event: The event.
+        """
+        super().hit(id_, event, *args, **kwargs)
+        if isinstance(event, FunctionEnterEvent):
+            stack = self._stack(id_, event.thread_id)
+            node = stack[-1].child(self.function_name(event))
+            stack.append(node)
+            self._record(id_, node, node.enter)
+        elif isinstance(event, (FunctionExitEvent, FunctionErrorEvent)):
+            stack = self._stack(id_, event.thread_id)
+            node = stack[-1]
+            if node is not self.root:
+                self._record(id_, node, node.exit)
+                stack.pop()
+
+    def _stack(self, id_: EventFile, thread_id: Optional[int]) -> List[TreeNode]:
+        """
+        Return the open call stack of one thread of a run.
+
+        :param id_: The run.
+        :param thread_id: The thread, or ``None`` when threads are not tracked.
+        :returns: The stack, rooted at the tree's root on first use.
+        """
+        stacks = self._stacks[id_]
+        stack = stacks.get(thread_id)
+        if stack is None:
+            stack = stacks[thread_id] = [self.root]
+        return stack
+
+    def _record(self, id_: EventFile, node: TreeNode, target: List[Dict[int, int]]):
+        """
+        Snapshot the run's current feature values into *target*.
+
+        :param id_: The run.
+        :param node: The node being observed.
+        :param target: The node's entry or exit observation list.
+        """
+        key = f"{node.name}:{id(target)}"
+        count = self._counts[id_][key]
+        if count >= self.per_run_cap:
+            # Keep the first observation and slide the last one.
+            target.pop()
+        else:
+            self._counts[id_][key] = count + 1
+        observation = dict()
+        for feature, value in self.feature_vectors[id_].get_features().items():
+            self.catalog[feature.id] = feature.name
+            observation[feature.id] = value.value
+        target.append(observation)
+
+    def merge(self, other: "TreeBuilder") -> None:
+        """
+        Fold a builder that handled other runs into this one.
+
+        Extends the vector merge with the tree: node structure is unioned and
+        observations are concatenated, which is exactly what makes a tree built
+        in pieces equal to one built in a single pass. Feature ids are content
+        digests, so observations recorded in another process are directly
+        comparable to these without translation.
+
+        :param other: A builder that handled a different set of runs.
+        """
+        super().merge(other)
+        self.catalog.update(other.catalog)
+        self.root.merge(other.root)
+
+    def post_process(self, event_file: EventFile) -> None:
+        """
+        Close the run by recording the root's exit observation.
+
+        :param event_file: The finished run.
+        """
+        self._record(event_file, self.root, self.root.exit)
+
+    def observations(self, node: TreeNode) -> List[Dict[str, FeatureValue]]:
+        """
+        Read a node's entry observations back as names and values.
+
+        :param node: The node to read.
+        :returns: One dict per observation.
+        """
+        return [
+            {
+                self.catalog[fid]: FeatureValue(value)
+                for fid, value in observation.items()
+            }
+            for observation in node.enter
+        ]

--- a/src/sflkit/runners/__init__.py
+++ b/src/sflkit/runners/__init__.py
@@ -7,6 +7,7 @@ from sflkit.runners.run import (
     UnittestRunner,
     InputRunner,
     ParallelPytestRunner,
+    OnlinePytestRunner,
 )
 
 
@@ -20,3 +21,5 @@ class RunnerType(enum.Enum):
     INPUT_RUNNER = InputRunner
     PARALLEL_PYTEST_RUNNER = ParallelPytestRunner
     PARALLEL_UNITTEST_RUNNER = UnittestRunner
+    ONLINE_PYTEST_RUNNER = OnlinePytestRunner
+    PARALLEL_ONLINE_PYTEST_RUNNER = OnlinePytestRunner

--- a/src/sflkit/runners/run.py
+++ b/src/sflkit/runners/run.py
@@ -44,8 +44,20 @@ class Runner(abc.ABC):
         timeout=DEFAULT_TIMEOUT,
         is_parallel: bool = False,
         thread_support: bool = False,
+        online: bool = False,
+        mapping_path: Optional[os.PathLike] = None,
+        root: Optional[os.PathLike] = None,
+        online_tree: bool = True,
     ):
         self.timeout = timeout
+        #: Build the analysis artifact inside the test process instead of
+        #: writing a trace for the parent to read back. Needs the event mapping
+        #: and the subject root, because a tracer works from the mapping rather
+        #: than from instrumented sources.
+        self.online = online
+        self.mapping_path = mapping_path
+        self.root = root
+        self.online_tree = online_tree
         self.re_filter = re.compile(re_filter)
         self.passing_tests = set()
         self.failing_tests = set()
@@ -93,6 +105,32 @@ class Runner(abc.ABC):
                 s = s.replace(c, "_")
         return s
 
+    def online_environ(self, output: Path, environ: Environment = None) -> Environment:
+        """
+        Add the settings the in-process collector reads on start-up.
+
+        :param output: Directory artifacts are written to.
+        :param environ: Environment to extend.
+        :returns: The extended environment.
+        :raises ValueError: When the mapping or the root is missing, without
+            which a tracer has nothing to recognize.
+        """
+        # Imported here: the plugin imports this module, so importing it at
+        # module level would close a cycle.
+        from sflkit.online import plugin
+
+        if self.mapping_path is None or self.root is None:
+            raise ValueError("Online collection needs mapping_path and root to be set")
+        environ = dict(environ if environ is not None else os.environ)
+        # Absolute: the collector reads these in the test process, which runs
+        # in the subject's directory rather than in this one.
+        environ[plugin.MAPPING] = str(Path(self.mapping_path).resolve())
+        environ[plugin.ROOT] = str(Path(self.root).resolve())
+        environ[plugin.OUTPUT] = str(Path(output).resolve())
+        environ[plugin.THREADS] = "1" if self.thread_support else "0"
+        environ[plugin.TREE] = "1" if self.online_tree else "0"
+        return environ
+
     def run_tests(
         self,
         directory: Path,
@@ -104,10 +142,18 @@ class Runner(abc.ABC):
         output.mkdir(parents=True, exist_ok=True)
         for test_result in TestResult:
             (output / test_result.get_dir()).mkdir(parents=True, exist_ok=True)
+        if self.online:
+            environ = self.online_environ(output, environ)
         for event_file, test in enumerate(tests):
             test_result = self.run_test(directory, test, environ=environ, python=python)
             self.tests[test_result].add(test)
-            if os.path.exists(directory / "EVENTS_PATH"):
+            if self.online:
+                # The collector already wrote this test's artifact, and it knew
+                # the verdict from the test report rather than from parsing
+                # output, so there is nothing to move.
+                if not (output / test_result.get_dir() / self.safe(test)).exists():
+                    LOGGER.warning(f"No artifact collected for test {test}")
+            elif os.path.exists(directory / "EVENTS_PATH"):
                 shutil.move(
                     directory / "EVENTS_PATH",
                     output / test_result.get_dir() / self.safe(test),
@@ -299,9 +345,28 @@ class PytestRunner(Runner):
         timeout=DEFAULT_TIMEOUT,
         set_python_path: bool = False,
         thread_support: bool = False,
+        online: bool = False,
+        mapping_path: Optional[os.PathLike] = None,
+        root: Optional[os.PathLike] = None,
+        online_tree: bool = True,
     ):
-        super().__init__(re_filter, timeout, thread_support=thread_support)
+        super().__init__(
+            re_filter,
+            timeout,
+            thread_support=thread_support,
+            online=online,
+            mapping_path=mapping_path,
+            root=root,
+            online_tree=online_tree,
+        )
         self.set_python_path = set_python_path
+
+    def pytest_args(self) -> List[str]:
+        """
+        :returns: Extra pytest arguments, loading the collector plugin when
+            events are gathered in-process.
+        """
+        return ["-p", "sflkit.online.plugin"] if self.online else []
 
     @staticmethod
     def use_parallel() -> type[Runner]:
@@ -470,7 +535,7 @@ class PytestRunner(Runner):
     ) -> TestResult:
         try:
             output = subprocess.run(
-                [python, "-m", "pytest", test],
+                [python, "-m", "pytest"] + self.pytest_args() + [test],
                 stdout=subprocess.PIPE,
                 env=environ,
                 cwd=directory,
@@ -491,6 +556,53 @@ class PytestRunner(Runner):
         else:
             LOGGER.debug(output.decode("utf8"))
             return TestResult.UNDEFINED
+
+
+class OnlinePytestRunner(PytestRunner):
+    """
+    Pytest runner that builds each test's artifact inside the test process.
+
+    Same contract as :class:`PytestRunner` -- it fills the same
+    ``passing``/``failing``/``undefined`` directories under the same names --
+    but what lands there is a compact artifact rather than an event trace, and
+    it is produced without a second pass over the events.
+
+    It runs the subject as shipped: a tracer works from the event mapping, so
+    the directory it is pointed at is the original source, not an instrumented
+    copy. Instrumentation is still what produces the mapping.
+    """
+
+    def __init__(
+        self,
+        re_filter: str = r".*",
+        timeout=DEFAULT_TIMEOUT,
+        set_python_path: bool = False,
+        thread_support: bool = False,
+        mapping_path: Optional[os.PathLike] = None,
+        root: Optional[os.PathLike] = None,
+        online_tree: bool = True,
+        **kwargs,
+    ):
+        """
+        :param mapping_path: Event mapping written by instrumentation.
+        :param root: Directory the mapping's file names are relative to, which
+            is also where the tests run.
+        :param online_tree: Build the call tree as well as the feature vector.
+        """
+        super().__init__(
+            re_filter,
+            timeout,
+            set_python_path=set_python_path,
+            thread_support=thread_support,
+            online=True,
+            mapping_path=mapping_path,
+            root=root,
+            online_tree=online_tree,
+        )
+
+    @staticmethod
+    def use_parallel() -> type[Runner]:
+        return OnlinePytestRunner
 
 
 class UnittestRunner(Runner):

--- a/src/sflkit/weights/models.py
+++ b/src/sflkit/weights/models.py
@@ -51,7 +51,9 @@ class TestTimeModel(ParallelModel):
         self, event, event_file: EventFile, scope: Scope = None
     ) -> Set["AnalysisObject"]:
         analysis = super().handle_event(event, event_file, scope)
-        self.current_analysis[event_file].extend(analysis)
+        # De-duplicated here rather than in the base model, which no longer
+        # pays for a set on every event just for this one caller.
+        self.current_analysis[event_file].extend(set(analysis))
         return analysis
 
     def add(

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -160,3 +160,48 @@ class TestAnalyzer(BaseTest):
             self.assertEqual(3, predicate.fail_false)
             self.assertEqual(4, predicate.increase_true)
             self.assertEqual(5, predicate.increase_false)
+
+
+class ProcessParallelAnalyzerTest(BaseTest):
+    """
+    Spreading runs over worker processes must not change the answer.
+
+    Runs are independent until suspiciousness is computed, so each worker can
+    analyze a share of them and the parent merges the per-run state before
+    scoring. What must hold is that the merged result is indistinguishable
+    from analyzing everything in one process.
+    """
+
+    EVENTS = "line,branch,def,use,function_enter,function_exit"
+    PREDICATES = "line,branch,def_use,scalar_pair,function"
+
+    def _analyze(self, processes: int):
+        config, relevant, irrelevant = self.run_analysis_event_files(
+            self.TEST_SUGGESTIONS,
+            self.EVENTS,
+            self.PREDICATES,
+            relevant=[["3", "2", "1"]],
+            irrelevant=[["1", "2", "3"], ["2", "1", "3"], ["3", "1", "2"]],
+        )
+        analyzer = Analyzer(
+            relevant,
+            irrelevant,
+            config.factory,
+            processes=processes,
+        )
+        analyzer.analyze()
+        return {
+            str(analysis): round(analysis.get_metric(), 8)
+            for analysis in analyzer.get_analysis()
+        }
+
+    def test_process_parallel_matches_serial(self):
+        serial = self._analyze(1)
+        parallel = self._analyze(2)
+        self.assertTrue(serial, "the subject produced no analysis")
+        self.assertEqual(serial, parallel)
+
+    def test_more_processes_than_runs_is_harmless(self):
+        serial = self._analyze(1)
+        parallel = self._analyze(16)
+        self.assertEqual(serial, parallel)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -80,7 +80,7 @@ class EventTests(BaseTest):
                 branch_i += 1
 
     @staticmethod
-    def _test_events(events):
+    def _test_events(events, environ: dict = None):
         config = Config.create(
             path=os.path.join(BaseTest.TEST_RESOURCES, "test_events"),
             language="python",
@@ -89,7 +89,11 @@ class EventTests(BaseTest):
         )
         instrument_config(config)
 
-        subprocess.run([BaseTest.PYTHON, BaseTest.ACCESS], cwd=BaseTest.TEST_DIR)
+        subprocess.run(
+            [BaseTest.PYTHON, BaseTest.ACCESS],
+            cwd=BaseTest.TEST_DIR,
+            env={**os.environ, **(environ or {})},
+        )
         return event.load(
             os.path.join(BaseTest.TEST_DIR, BaseTest.TEST_PATH),
             EventMapping.load(config).mapping,
@@ -199,7 +203,13 @@ class EventTests(BaseTest):
                 branches_i += 1
 
     def test_loop(self):
-        events = self._test_events("loop_begin,loop_hit,loop_end")
+        # Budgets off: this checks that a loop produces begin/hit/end events,
+        # not that the runtime stops recording hits once it has seen enough.
+        # With the default EVENTS_MAX_LOOP_HITS of 2 the later hits are
+        # deliberately dropped, which is the subject of its own test.
+        events = self._test_events(
+            "loop_begin,loop_hit,loop_end", {"EVENTS_MAX_LOOP_HITS": "0"}
+        )
         self.assertEqual(12, len(events))
         expected_loop = [
             (event.EventType.LOOP_BEGIN, 11),

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -2,13 +2,17 @@ import unittest
 from concurrent.futures.thread import ThreadPoolExecutor
 
 from sflkit.analysis.analysis_type import MetaEvent
+from sflkit.analysis.factory import DefUseFactory
 from sflkit.analysis.predicate import Branch
 from sflkit.analysis.spectra import Line
 from sflkit.events.event_file import EventFile
 from sflkit.events.mapping import EventMapping
-from sflkit.features.handler import EventHandler
+from sflkit.features.handler import EventHandler, FeatureBuilder
 from sflkit.features.value import FeatureValue, BinaryFeature, TertiaryFeature
 from sflkit.features.vector import FeatureVector
+from sflkit.model.model import Model
+from sflkit.model.scope import Scope
+from sflkitlib.events.event import DefEvent, UseEvent
 from sflkit.runners.run import TestResult
 from utils import BaseTest
 
@@ -449,3 +453,162 @@ class HandlerTest(BaseTest):
         for feature in self.features.values():
             self.assertEqual(self.failing_vector[feature].value, fail_row[feature.name])
             self.assertEqual(self.passing_vector[feature].value, pass_row[feature.name])
+
+
+class ScopeReleaseTest(unittest.TestCase):
+    """
+    Per-scope analysis state must die with its scope.
+
+    Scope ids are handed out per function call, so anything a factory keeps per
+    scope grows with the number of calls a run makes. The def-use factory used
+    to keep one dict, and every DefEvent in it, for every call ever made: a
+    20,000-call run retained 180,000 events.
+    """
+
+    def setUp(self):
+        self.factory = DefUseFactory()
+        self.run = EventFile("EVENTS", 0, EventMapping())
+
+    def _define(self, scope: Scope, index: int) -> None:
+        event = DefEvent("main.py", 1, 0, "x", index, index, "int")
+        self.factory.get_analysis(event, self.run, scope)
+
+    def test_leaving_a_scope_releases_its_definitions(self):
+        for index in range(100):
+            scope = Scope()
+            self._define(scope, index)
+            self.factory.exit_scope(self.run, scope.id)
+        self.assertEqual(
+            0,
+            len(self.factory.def_stack[self.run]),
+            "definitions of ended scopes are still retained",
+        )
+
+    def test_state_accumulates_while_scopes_are_live(self):
+        scopes = [Scope() for _ in range(10)]
+        for index, scope in enumerate(scopes):
+            self._define(scope, index)
+        self.assertEqual(
+            10,
+            len(self.factory.def_stack[self.run]),
+            "a live scope must keep its definitions",
+        )
+
+    def test_model_reports_scope_exits_to_the_factory(self):
+        model = Model(self.factory)
+        model.prepare(self.run)
+        model.enter_scope(self.run)
+        self._define(model.variables[self.run], 0)
+        self.assertEqual(1, len(self.factory.def_stack[self.run]))
+        model.exit_scope(self.run)
+        self.assertEqual(
+            0,
+            len(self.factory.def_stack[self.run]),
+            "the model must tell factories when a scope ends",
+        )
+
+
+class DefUseResolutionTest(unittest.TestCase):
+    """
+    A use must find its definition through the scope chain.
+
+    Looking only in the innermost scope missed everything a caller defined,
+    which is why a map of every definition ever made was kept as a fallback.
+    That map is keyed by ``id(value)``, so it grew without bound and, because
+    CPython recycles ids, could match a definition of an unrelated object.
+    """
+
+    def setUp(self):
+        self.factory = DefUseFactory()
+        self.run = EventFile("EVENTS", 0, EventMapping())
+
+    def _define(self, scope: Scope, var: str, var_id: int) -> None:
+        self.factory.get_analysis(
+            DefEvent("main.py", 1, 0, var, var_id, var_id, "int"), self.run, scope
+        )
+
+    def _use(self, scope: Scope, var: str, var_id: int):
+        return self.factory.get_analysis(
+            UseEvent("main.py", 2, 1, var, var_id), self.run, scope
+        )
+
+    def test_use_finds_a_definition_from_an_enclosing_scope(self):
+        outer = Scope()
+        self._define(outer, "x", 7)
+        inner = outer.enter()
+        self.assertTrue(
+            self._use(inner, "x", 7), "a use must see the enclosing scope's definition"
+        )
+
+    def test_use_does_not_find_a_definition_from_a_dead_scope(self):
+        outer = Scope()
+        sibling = outer.enter()
+        self._define(sibling, "x", 7)
+        self.factory.exit_scope(self.run, sibling.id)
+        other = outer.enter()
+        self.assertFalse(
+            self._use(other, "x", 7),
+            "a definition from a scope that ended must not resolve",
+        )
+
+    def test_cross_thread_fallback_is_bounded(self):
+        scope = Scope()
+        for index in range(DefUseFactory.CROSS_THREAD_LIMIT + 500):
+            self._define(scope, "x", index)
+        self.assertLessEqual(
+            len(self.factory.id_to_def[self.run]),
+            DefUseFactory.CROSS_THREAD_LIMIT,
+            "the cross-thread map must stay bounded",
+        )
+
+
+class ProcessParallelBuilderTest(BaseTest):
+    """
+    Spreading runs over worker processes must not change what is built.
+
+    Runs are independent, so each worker can build from its share and the
+    parent merges. What must hold is that the merged result is
+    indistinguishable from building everything in one process.
+    """
+
+    EVENTS = "line,branch,def,use,function_enter,function_exit"
+
+    def _event_files(self):
+        _, relevant, irrelevant = self.run_analysis_event_files(
+            self.TEST_SUGGESTIONS,
+            self.EVENTS,
+            "line,branch,def_use,scalar_pair",
+            relevant=[["3", "2", "1"]],
+            irrelevant=[["1", "2", "3"], ["2", "1", "3"], ["3", "1", "2"]],
+        )
+        return relevant + irrelevant
+
+    @staticmethod
+    def _vectors(handler):
+        return {
+            str(vector.run_id): {
+                feature.name: value.value
+                for feature, value in vector.get_features().items()
+            }
+            for vector in handler.builder.get_vectors()
+        }
+
+    def test_vectors_match_a_single_process(self):
+        event_files = self._event_files()
+        serial = EventHandler(workers=1)
+        serial.handle_files(event_files)
+        parallel = EventHandler(workers=1, processes=2)
+        parallel.handle_files(event_files)
+        self.assertTrue(self._vectors(serial), "no vectors were built")
+        self.assertEqual(self._vectors(serial), self._vectors(parallel))
+
+    def test_feature_set_matches_a_single_process(self):
+        event_files = self._event_files()
+        serial = EventHandler(workers=1)
+        serial.handle_files(event_files)
+        parallel = EventHandler(workers=1, processes=3)
+        parallel.handle_files(event_files)
+        self.assertEqual(
+            {feature.name for feature in serial.builder.all_features},
+            {feature.name for feature in parallel.builder.all_features},
+        )

--- a/tests/test_online.py
+++ b/tests/test_online.py
@@ -1,0 +1,741 @@
+"""
+Tests for online (in-process) artifact construction.
+
+The load-bearing test is equivalence: for the same subject and the same input,
+the events a tracer materializes must be the events instrumentation writes into
+a trace. Everything else the online path produces is built by the existing
+analysis layer from those events, so if the events agree, the artifacts agree.
+"""
+
+import os
+import runpy
+import shutil
+import subprocess
+import sys
+import threading
+import unittest
+from pathlib import Path
+from typing import List, Optional
+
+from sflkitlib.events import EventType
+from sflkitlib.events.event import Event
+
+from sflkit import Config, instrument_config
+from sflkit.analysis.analysis_type import AnalysisType
+from sflkit.events.event_file import EventFile
+from sflkit.events.mapping import EventMapping
+from sflkit.features.handler import EventHandler
+from sflkit.features.value import FeatureValue, feature_id
+from sflkit.online import (
+    EventListener,
+    ListenerGroup,
+    LocationIndex,
+    MonitoringTracer,
+    OnlineSession,
+    RunArtifact,
+    SUPPORTED_EVENT_TYPES,
+    SpectrumListener,
+    Suite,
+    SysTraceTracer,
+    TreeBuilder,
+    TreeNode,
+    get_tracer,
+    trace,
+)
+from sflkit.online.tracer import value_and_type
+from sflkit.runners import RunnerType
+from sflkit.runners.run import OnlinePytestRunner, PytestRunner, TestResult
+from utils import BaseTest
+
+
+class RecordingListener(EventListener):
+    """Keeps every event it is given, for comparison against a trace."""
+
+    def __init__(self):
+        self.events: List[Event] = list()
+        self.runs: List[EventFile] = list()
+
+    def start(self, run: EventFile) -> None:
+        self.runs.append(run)
+
+    def event(self, event: Event) -> None:
+        self.events.append(event)
+
+
+class OnlineTest(BaseTest):
+    """Shared plumbing: instrument a subject, then run it offline and online."""
+
+    ALL_EVENTS = (
+        "line,branch,def,use,len,loop_begin,loop_hit,loop_end,"
+        "function_enter,function_exit,function_error"
+    )
+
+    def setUp(self):
+        self.work = Path(self.TEST_DIR)
+        shutil.rmtree(self.work, ignore_errors=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.work, ignore_errors=True)
+        for leftover in (self.TEST_MAPPING, self.TEST_PATH):
+            if os.path.exists(leftover):
+                os.remove(leftover)
+
+    def instrument(self, subject: str, events: str = None, predicates: str = ""):
+        """
+        Instrument *subject* and return its config, mapping and source directory.
+
+        The tracer runs the ORIGINAL sources, so the source directory it is
+        pointed at is the subject itself, not the instrumented copy.
+        """
+        source = Path(self.TEST_RESOURCES) / subject
+        config = Config.create(
+            path=str(source),
+            language="python",
+            events=events or self.ALL_EVENTS,
+            predicates=predicates,
+            working=str(self.work),
+            mapping_path=self.TEST_MAPPING,
+        )
+        instrument_config(config)
+        return config, EventMapping.load(config), source
+
+    def offline_events(self, config, mapping, args: List[str]) -> List[Event]:
+        """Run the instrumented copy in a subprocess and decode its trace."""
+        subprocess.run(
+            [self.PYTHON, self.ACCESS] + args,
+            cwd=self.work,
+            env=os.environ,
+            check=False,
+        )
+        trace_path = self.work / self.TEST_PATH
+        with EventFile(trace_path, 0, mapping) as event_file:
+            return list(event_file.load())
+
+    def online_events(
+        self,
+        source: Path,
+        mapping: EventMapping,
+        args: List[str],
+        prefer_monitoring: bool = True,
+        thread_support: bool = False,
+    ) -> List[Event]:
+        """Run the original sources in this process under a tracer."""
+        listener = RecordingListener()
+        index = LocationIndex(mapping, source)
+        tracer = get_tracer(
+            index,
+            listener,
+            thread_support=thread_support,
+            prefer_monitoring=prefer_monitoring,
+        )
+        listener.start(EventFile(Path("online"), 0, None, False))
+        self.execute(source, args, tracer)
+        return listener.events
+
+    @staticmethod
+    def execute(source: Path, args: List[str], tracer) -> None:
+        """Execute ``main.py`` of *source* with *args* under *tracer*."""
+        argv = sys.argv
+        sys.argv = [str(source / "main.py")] + args
+        try:
+            with tracer:
+                try:
+                    runpy.run_path(str(source / "main.py"), run_name="__main__")
+                except SystemExit:
+                    pass
+        finally:
+            sys.argv = argv
+
+    @staticmethod
+    def ids(events: List[Event]) -> List[int]:
+        """Event ids of the events a tracer is able to materialize."""
+        return [
+            event.event_id
+            for event in events
+            if event.event_type in SUPPORTED_EVENT_TYPES
+        ]
+
+
+class EquivalenceTest(OnlineTest):
+    """The tracer must reproduce the instrumented trace."""
+
+    def test_event_sequence_matches_trace(self):
+        config, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        offline = self.offline_events(config, mapping, ["3", "2", "1"])
+        online = self.online_events(source, mapping, ["3", "2", "1"])
+        self.assertEqual(self.ids(offline), self.ids(online))
+
+    def test_event_sequence_matches_trace_with_settrace(self):
+        config, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        offline = self.offline_events(config, mapping, ["3", "2", "1"])
+        online = self.online_events(
+            source, mapping, ["3", "2", "1"], prefer_monitoring=False
+        )
+        self.assertEqual(self.ids(offline), self.ids(online))
+
+    def test_def_events_carry_the_assigned_value(self):
+        config, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        offline = self.offline_events(config, mapping, ["3", "2", "1"])
+        online = self.online_events(source, mapping, ["3", "2", "1"])
+        expected = [
+            (event.event_id, event.var, event.value, event.type_)
+            for event in offline
+            if event.event_type is EventType.DEF
+        ]
+        actual = [
+            (event.event_id, event.var, event.value, event.type_)
+            for event in online
+            if event.event_type is EventType.DEF
+        ]
+        self.assertEqual(expected, actual)
+        self.assertTrue(expected, "subject produced no def events")
+
+    def test_function_exit_events_carry_the_return_value(self):
+        config, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        offline = self.offline_events(config, mapping, ["3", "2", "1"])
+        online = self.online_events(source, mapping, ["3", "2", "1"])
+        expected = [
+            (event.event_id, event.return_value, event.type_)
+            for event in offline
+            if event.event_type is EventType.FUNCTION_EXIT
+        ]
+        actual = [
+            (event.event_id, event.return_value, event.type_)
+            for event in online
+            if event.event_type is EventType.FUNCTION_EXIT
+        ]
+        self.assertEqual(expected, actual)
+        self.assertTrue(expected, "subject produced no function exit events")
+
+    def test_loops_match_trace(self):
+        config, mapping, source = self.instrument(self.TEST_LOOP)
+        offline = self.offline_events(config, mapping, ["abc"])
+        online = self.online_events(source, mapping, ["abc"])
+        self.assertEqual(self.ids(offline), self.ids(online))
+
+    def test_len_events_match_trace(self):
+        config, mapping, source = self.instrument(self.TEST_LEN)
+        offline = self.offline_events(config, mapping, ["abc"])
+        online = self.online_events(source, mapping, ["abc"])
+        self.assertEqual(
+            [(e.event_id, e.length) for e in offline if e.event_type is EventType.LEN],
+            [(e.event_id, e.length) for e in online if e.event_type is EventType.LEN],
+        )
+
+    def test_function_error_matches_trace(self):
+        config, mapping, source = self.instrument(self.TEST_ERROR)
+        offline = self.offline_events(config, mapping, ["0"])
+        online = self.online_events(source, mapping, ["0"])
+        self.assertEqual(self.ids(offline), self.ids(online))
+
+    def test_conditions_are_reported_as_unsupported(self):
+        _, mapping, source = self.instrument(self.TEST_SUGGESTIONS, events="condition")
+        index = LocationIndex(mapping, source)
+        self.assertIn(EventType.CONDITION, index.skipped)
+
+
+class VectorTest(OnlineTest):
+    """Feature vectors built online must equal those built from a trace."""
+
+    def test_feature_vector_matches_offline(self):
+        config, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        self.offline_events(config, mapping, ["3", "2", "1"])
+        handler = EventHandler()
+        handler.handle(EventFile(self.work / self.TEST_PATH, 0, mapping, True))
+        offline_vector = handler.builder.get_vectors()[0]
+
+        with trace(mapping, source, name="middle", failing=True) as session:
+            self.execute(source, ["3", "2", "1"], session.tracer)
+        artifact = session.artifact()
+
+        expected = {
+            feature.name: value.value
+            for feature, value in offline_vector.get_features().items()
+            if feature.analysis.analysis_type() not in (AnalysisType.CONDITION,)
+        }
+        actual = {
+            artifact.catalog[fid]: value for fid, value in artifact.features.items()
+        }
+        self.assertTrue(expected, "offline run produced no features")
+        self.assertEqual(expected, actual)
+
+    def test_artifact_result_follows_the_verdict(self):
+        _, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        with trace(mapping, source, name="t", failing=False) as session:
+            self.execute(source, ["3", "2", "1"], session.tracer)
+        self.assertEqual(TestResult.PASSING, session.artifact().result)
+        with trace(mapping, source, name="t", failing=None) as session:
+            self.execute(source, ["3", "2", "1"], session.tracer)
+        self.assertEqual(TestResult.UNDEFINED, session.artifact().result)
+
+
+class SpectrumTest(OnlineTest):
+    """Spectra built online must equal those built from a trace."""
+
+    def test_spectra_match_offline(self):
+        config, mapping, source = self.instrument(
+            self.TEST_SUGGESTIONS, events="line,branch", predicates="line,branch"
+        )
+        offline = self.offline_events(config, mapping, ["3", "2", "1"])
+        self.assertTrue(offline)
+
+        listener = SpectrumListener(types=[AnalysisType.LINE, AnalysisType.BRANCH])
+        index = LocationIndex(mapping, source)
+        tracer = get_tracer(index, listener)
+        run = EventFile(Path("online"), 0, None, True)
+        listener.start(run)
+        self.execute(source, ["3", "2", "1"], tracer)
+        listener.stop()
+        listener.finalize([], [run])
+
+        online_names = {str(analysis) for analysis in listener.analysis}
+        from sflkit.analysis.analyzer import Analyzer
+
+        analyzer = Analyzer(
+            [EventFile(self.work / self.TEST_PATH, 0, mapping, True)],
+            [],
+            config.factory,
+        )
+        analyzer.analyze()
+        offline_names = {str(analysis) for analysis in analyzer.get_analysis()}
+        self.assertTrue(offline_names)
+        self.assertEqual(offline_names, online_names)
+
+
+class TreeTest(OnlineTest):
+    """The call tree must be built online and merge across runs."""
+
+    def test_tree_records_functions_with_observations(self):
+        _, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        with trace(mapping, source, name="t", failing=True) as session:
+            self.execute(source, ["3", "2", "1"], session.tracer)
+        tree = session.artifact().tree
+        names = {node.name for node in tree.walk()}
+        self.assertTrue(
+            any("middle" in name for name in names),
+            f"middle not recorded in {names}",
+        )
+        middle = next(node for node in tree.walk() if "middle" in node.name)
+        self.assertTrue(middle.enter, "no entry observation recorded")
+        self.assertTrue(middle.exit, "no exit observation recorded")
+        self.assertTrue(
+            all(isinstance(key, int) for key in middle.enter[0]),
+            "observations must be keyed by feature id",
+        )
+
+    def test_trees_merge_across_runs(self):
+        _, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        artifacts = []
+        for index, (args, failing) in enumerate(
+            ([["3", "2", "1"], True], [["1", "2", "3"], False])
+        ):
+            with trace(mapping, source, name=f"t{index}", failing=failing) as session:
+                self.execute(source, args, session.tracer)
+            artifacts.append(session.artifact())
+
+        suite = Suite.merge(artifacts)
+        self.assertEqual(
+            [TestResult.FAILING, TestResult.PASSING],
+            [artifact.result for artifact in suite.runs],
+            "failing runs must merge first",
+        )
+        merged = next(node for node in suite.tree.walk() if "middle" in node.name)
+        separate = [
+            next(node for node in artifact.tree.walk() if "middle" in node.name)
+            for artifact in artifacts
+        ]
+        self.assertEqual(
+            sum(len(node.enter) for node in separate),
+            len(merged.enter),
+            "merging must keep every run's observations",
+        )
+
+    def test_merge_is_order_independent(self):
+        a, b = TreeNode("ROOT"), TreeNode("ROOT")
+        a.child("f").enter.append({1: 1})
+        b.child("g").enter.append({2: 0})
+        forward, backward = TreeNode("ROOT"), TreeNode("ROOT")
+        forward.merge(a)
+        forward.merge(b)
+        backward.merge(b)
+        backward.merge(a)
+        self.assertEqual(
+            sorted(node.name for node in forward.walk()),
+            sorted(node.name for node in backward.walk()),
+        )
+
+    def test_observations_are_capped_per_run(self):
+        _, mapping, source = self.instrument(self.TEST_LOOP)
+        with trace(mapping, source, name="t", failing=True) as session:
+            self.execute(source, ["abcdefghij"], session.tracer)
+        tree = session.artifact().tree
+        for node in tree.walk():
+            self.assertLessEqual(
+                len(node.enter), session.builder.per_run_cap, f"{node.name} uncapped"
+            )
+
+
+class ThreadTest(OnlineTest):
+    """Threaded subjects must not have their scopes mixed up."""
+
+    SUBJECT = "test_online_threads"
+
+    def setUp(self):
+        super().setUp()
+        self.source = Path(self.TEST_RESOURCES) / self.SUBJECT
+        self.source.mkdir(parents=True, exist_ok=True)
+        (self.source / "main.py").write_text(
+            "import threading\n"
+            "\n"
+            "\n"
+            "def work(n):\n"
+            "    total = 0\n"
+            "    for i in range(n):\n"
+            "        total += i\n"
+            "    return total\n"
+            "\n"
+            "\n"
+            "threads = [threading.Thread(target=work, args=(3,)) for _ in range(3)]\n"
+            "for t in threads:\n"
+            "    t.start()\n"
+            "for t in threads:\n"
+            "    t.join()\n"
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.source, ignore_errors=True)
+
+    def test_events_from_threads_carry_distinct_ids(self):
+        _, mapping, source = self.instrument(self.SUBJECT)
+        listener = RecordingListener()
+        tracer = get_tracer(
+            LocationIndex(mapping, source), listener, thread_support=True
+        )
+        listener.start(EventFile(Path("online"), 0, None, False))
+        self.execute(source, [], tracer)
+        thread_ids = {event.thread_id for event in listener.events}
+        self.assertGreater(
+            len(thread_ids), 1, f"expected several threads, saw {thread_ids}"
+        )
+        self.assertNotIn(None, thread_ids)
+
+    def test_thread_ids_are_absent_without_thread_support(self):
+        _, mapping, source = self.instrument(self.SUBJECT)
+        listener = RecordingListener()
+        tracer = get_tracer(
+            LocationIndex(mapping, source), listener, thread_support=False
+        )
+        listener.start(EventFile(Path("online"), 0, None, False))
+        self.execute(source, [], tracer)
+        self.assertEqual({None}, {event.thread_id for event in listener.events})
+
+    def test_tree_keeps_one_stack_per_thread(self):
+        _, mapping, source = self.instrument(self.SUBJECT)
+        with trace(
+            mapping, source, name="t", failing=True, thread_support=True
+        ) as session:
+            self.execute(source, [], session.tracer)
+        tree = session.artifact().tree
+        work = [node for node in tree.walk() if "work" in node.name]
+        self.assertEqual(
+            1, len(work), "one function must yield one node regardless of threads"
+        )
+        self.assertEqual(
+            len(work[0].enter),
+            len(work[0].exit),
+            "every entry must have a matching exit",
+        )
+
+
+class ArtifactTest(OnlineTest):
+    """Artifacts must survive the trip between processes."""
+
+    def test_feature_ids_are_stable_across_processes(self):
+        name = "Line(main.py:12)"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from sflkit.features.value import feature_id;"
+                f"print(feature_id({name!r}))",
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONHASHSEED": "1"},
+        )
+        self.assertEqual(str(feature_id(name)), result.stdout.strip())
+
+    def test_artifact_round_trips(self):
+        _, mapping, source = self.instrument(self.TEST_SUGGESTIONS)
+        with trace(mapping, source, name="t", failing=True) as session:
+            self.execute(source, ["3", "2", "1"], session.tracer)
+        artifact = session.artifact()
+        path = self.work / "artifact.pkl"
+        self.work.mkdir(parents=True, exist_ok=True)
+        artifact.dump(path)
+        loaded = RunArtifact.load(path)
+        self.assertEqual(artifact.run, loaded.run)
+        self.assertEqual(artifact.result, loaded.result)
+        self.assertEqual(artifact.features, loaded.features)
+        self.assertEqual(
+            [node.name for node in artifact.tree.walk()],
+            [node.name for node in loaded.tree.walk()],
+        )
+
+    def test_artifact_reads_uncompressed(self):
+        artifact = RunArtifact("t", TestResult.FAILING, {1: 1}, {1: "f"})
+        path = self.work / "plain.pkl"
+        self.work.mkdir(parents=True, exist_ok=True)
+        artifact.dump(path, compress=False)
+        self.assertEqual({1: 1}, RunArtifact.load(path).features)
+
+    def test_counts_aggregate_runs(self):
+        suite = Suite.merge(
+            [
+                RunArtifact("f", TestResult.FAILING, {1: 1, 2: 0}, {1: "a", 2: "b"}),
+                RunArtifact("p", TestResult.PASSING, {1: 1}, {1: "a", 2: "b"}),
+            ]
+        )
+        counts = suite.counts()
+        self.assertEqual({"ef": 1, "nf": 0, "ep": 1, "np": 0}, counts[1])
+        self.assertEqual({"ef": 0, "nf": 1, "ep": 0, "np": 1}, counts[2])
+
+
+class BackendTest(OnlineTest):
+    """Both backends must be selectable and clean up after themselves."""
+
+    def test_get_tracer_prefers_monitoring_when_available(self):
+        _, mapping, source = self.instrument(self.TEST_LINES)
+        index = LocationIndex(mapping, source)
+        tracer = get_tracer(index, RecordingListener())
+        expected = MonitoringTracer if MonitoringTracer.available() else SysTraceTracer
+        self.assertIsInstance(tracer, expected)
+
+    def test_monitoring_tracer_releases_its_tool_id(self):
+        if not MonitoringTracer.available():
+            self.skipTest("sys.monitoring is unavailable")
+        _, mapping, source = self.instrument(self.TEST_LINES)
+        index = LocationIndex(mapping, source)
+        for _ in range(3):
+            tracer = MonitoringTracer(index, RecordingListener())
+            tracer.start()
+            tracer.stop()
+        self.assertFalse(tracer.running)
+
+    def test_settrace_tracer_restores_the_previous_hook(self):
+        _, mapping, source = self.instrument(self.TEST_LINES)
+        tracer = SysTraceTracer(LocationIndex(mapping, source), RecordingListener())
+        before = sys.gettrace()
+        tracer.start()
+        tracer.stop()
+        self.assertIs(before, sys.gettrace())
+
+    def test_listener_failures_do_not_reach_the_subject(self):
+        class Broken(EventListener):
+            def event(self, event):
+                raise RuntimeError("listener is broken")
+
+        _, mapping, source = self.instrument(self.TEST_LINES)
+        tracer = get_tracer(LocationIndex(mapping, source), Broken())
+        # A broken listener must cost events, never the run.
+        self.execute(source, [], tracer)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class RunnerIntegrationTest(BaseTest):
+    """The runner must be able to collect artifacts instead of traces."""
+
+    def setUp(self):
+        self.work = Path(self.TEST_DIR)
+        self.subject = Path(self.TEST_DIR_2)
+        shutil.rmtree(self.work, ignore_errors=True)
+        shutil.rmtree(self.subject, ignore_errors=True)
+        # The tracer runs the subject as shipped, so the tests execute against
+        # a copy of the original sources; instrumentation only supplies the
+        # event mapping.
+        shutil.copytree(Path(self.TEST_RESOURCES) / self.TEST_RUNNER, self.subject)
+
+    def tearDown(self):
+        shutil.rmtree(self.work, ignore_errors=True)
+        shutil.rmtree(self.subject, ignore_errors=True)
+        for leftover in (self.TEST_MAPPING, self.TEST_PATH):
+            if os.path.exists(leftover):
+                os.remove(leftover)
+
+    def _mapping(self):
+        config = Config.create(
+            path=str(Path(self.TEST_RESOURCES) / self.TEST_RUNNER),
+            language="python",
+            events="line,branch,def,use,function_enter,function_exit",
+            predicates="",
+            working=str(self.work),
+            exclude="tests",
+            mapping_path=self.TEST_MAPPING,
+        )
+        instrument_config(config)
+        return config
+
+    def _run(self, runner):
+        output = (self.subject / "events").absolute()
+        runner.run(self.subject, output, files=[Path("tests", "test_middle.py")])
+        return output
+
+    def test_runner_collects_artifacts_instead_of_traces(self):
+        self._mapping()
+        runner = OnlinePytestRunner(
+            set_python_path=True,
+            mapping_path=self.TEST_MAPPING,
+            root=self.subject,
+        )
+        output = self._run(runner)
+        self.assertTrue(runner.failing_tests, "no failing test was found")
+        self.assertTrue(runner.passing_tests, "no passing test was found")
+
+        artifacts = []
+        for result in (TestResult.PASSING, TestResult.FAILING):
+            directory = output / result.get_dir()
+            self.assertTrue(list(directory.iterdir()), f"no artifact in {directory}")
+            for path in directory.iterdir():
+                artifact = RunArtifact.load(path)
+                self.assertEqual(result, artifact.result)
+                self.assertTrue(artifact.features, f"{artifact.run} observed nothing")
+                artifacts.append(artifact)
+
+        suite = Suite.merge(artifacts)
+        self.assertEqual(
+            TestResult.FAILING,
+            suite.runs[0].result,
+            "failing runs must come first in a merged suite",
+        )
+        counts = suite.counts()
+        self.assertTrue(counts)
+        discriminating = [
+            feature_id
+            for feature_id, count in counts.items()
+            if count["ef"] > 0 and count["ep"] == 0
+        ]
+        self.assertTrue(
+            discriminating, "no feature separates the failing run from the passing ones"
+        )
+
+    def test_no_traces_are_written(self):
+        self._mapping()
+        runner = OnlinePytestRunner(
+            set_python_path=True,
+            mapping_path=self.TEST_MAPPING,
+            root=self.subject,
+        )
+        self._run(runner)
+        self.assertFalse(
+            list(self.subject.rglob("EVENTS_PATH")),
+            "online collection must not write event traces",
+        )
+
+    def test_plugin_is_only_loaded_when_online(self):
+        offline = PytestRunner()
+        online = OnlinePytestRunner(mapping_path=self.TEST_MAPPING, root=self.subject)
+        self.assertEqual([], offline.pytest_args())
+        self.assertEqual(["-p", "sflkit.online.plugin"], online.pytest_args())
+
+    def test_online_needs_a_mapping(self):
+        runner = PytestRunner(online=True)
+        with self.assertRaises(ValueError):
+            runner.online_environ(self.subject)
+
+    def test_runner_type_exposes_the_online_runner(self):
+        self.assertIs(OnlinePytestRunner, RunnerType["ONLINE_PYTEST_RUNNER"].runner)
+
+
+class ProcessParallelTreeTest(OnlineTest):
+    """A tree built in pieces must equal one built in a single pass."""
+
+    def _event_files(self, mapping, args):
+        files = []
+        for index, arguments in enumerate(args):
+            self.offline_events(None, mapping, arguments)
+            target = self.work / f"run_{index}"
+            shutil.move(self.work / self.TEST_PATH, target)
+            files.append(EventFile(target, index, mapping, index == 0))
+        return files
+
+    @staticmethod
+    def _shape(builder):
+        return sorted(
+            (node.name, len(node.enter), len(node.exit)) for node in builder.root.walk()
+        )
+
+    def test_tree_matches_a_single_process(self):
+        _, mapping, _ = self.instrument(self.TEST_SUGGESTIONS)
+        event_files = self._event_files(
+            mapping, [["3", "2", "1"], ["1", "2", "3"], ["2", "1", "3"]]
+        )
+        serial = EventHandler(workers=1)
+        serial.builder = TreeBuilder()
+        serial.model = type(serial.model)(serial.builder)
+        serial.handle_files(event_files)
+
+        parallel = EventHandler(workers=1, processes=2)
+        parallel.builder = TreeBuilder()
+        parallel.model = type(parallel.model)(parallel.builder)
+        parallel.handle_files(event_files)
+
+        self.assertTrue(
+            any("middle" in name for name, _, _ in self._shape(serial.builder)),
+            "the subject produced no tree",
+        )
+        self.assertEqual(self._shape(serial.builder), self._shape(parallel.builder))
+        self.assertEqual(serial.builder.catalog, parallel.builder.catalog)
+
+
+class BudgetTest(OnlineTest):
+    """
+    The tracer must respect the same trace budgets as the instrumented runtime.
+
+    Without them the two collection paths diverge on any loop that runs more
+    than the budget allows: the runtime stops recording hits while the tracer
+    keeps going, so online spectra would be strictly richer than offline ones
+    and the two would no longer be comparable.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._environ = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._environ)
+        super().tearDown()
+
+    def _loop_hits(self, events):
+        return len([e for e in events if e.event_type is EventType.LOOP_HIT])
+
+    def test_loop_hits_are_capped(self):
+        os.environ["EVENTS_MAX_LOOP_HITS"] = "1"
+        _, mapping, source = self.instrument(self.TEST_LOOP)
+        events = self.online_events(source, mapping, ["abcdefgh"])
+        self.assertEqual(
+            1, self._loop_hits(events), "hits beyond the budget must be dropped"
+        )
+
+    def test_loop_hits_are_unbounded_when_the_budget_is_off(self):
+        os.environ["EVENTS_MAX_LOOP_HITS"] = "0"
+        _, mapping, source = self.instrument(self.TEST_LOOP)
+        events = self.online_events(source, mapping, ["abcdefgh"])
+        self.assertEqual(
+            8, self._loop_hits(events), "a disabled budget must record every hit"
+        )
+
+    def test_oversized_values_are_truncated(self):
+        self.assertEqual(("abcd", "str"), value_and_type("abcdefgh", 4))
+        self.assertEqual((b"ab", "bytes"), value_and_type(b"abcdef", 2))
+        self.assertEqual(("abcdefgh", "str"), value_and_type("abcdefgh", 0))
+
+    def test_numbers_are_never_truncated(self):
+        # A number has no prefix to keep, and asking for its length raises.
+        self.assertEqual((123456789, "int"), value_and_type(123456789, 2))
+        self.assertEqual((1.5, "float"), value_and_type(1.5, 2))
+        self.assertEqual((None, "NoneType"), value_and_type(None, 2))


### PR DESCRIPTION
Two things: a second way to collect events, and a much faster analysis layer. Java stays unwired on this line and arrives with its own release.

Requires `sflkitlib>=0.2.4`, published to PyPI today, which is the first version carrying both the condition-value events and the trace budgets this relies on.

## Online collection (`sflkit/online`)

The existing workflow is untouched: instrument, execute, write a trace, read it back. Alongside it, spectra, feature vectors and a call tree can now be built **while the program runs**. A tracer reconstructs the same events from CPython's monitoring hooks plus the static event mapping, so the subject runs as shipped rather than as an instrumented copy. The analysis layer cannot tell the two sources apart — it is driven with exactly what the offline path drives it with.

Two backends: `sys.monitoring` on 3.12+, `sys.settrace` elsewhere. Line events are enabled per code object, because enabling them globally instruments sflkit's own analysis in the same process and costs 20%.

Some of what a mapping does not record had to be recovered from the source: the two branch probes of one statement share a line and are told apart by where execution goes next; loop probes split into three groups on one line; parameters are bound at entry, not when the `def` line runs; defs are observable only after their line has run. `CONDITION` and `CONDITION_VALUE` are deliberately not materialized — recovering them means re-evaluating a subject expression, which a probe must never do.

Artifacts are mergeable by construction: observations are keyed by a content digest of the feature name, so records made in another process combine without shipping the analysis graph. `OnlinePytestRunner` writes one artifact per test where a trace used to go — 5.84 MB of trace becomes 9 KB.

The tracer applies the same `EVENTS_MAX_LOOP_HITS` and `EVENTS_MAX_VALUE_BYTES` budgets as the runtime; without them the two paths diverge on any loop that runs more than twice.

## Performance

Driven by profiling, not guesswork. On a 20k-iteration subject (604,770 events):

| | before | after |
|---|---|---|
| end to end | 36.3 s | 12.5 s |
| peak RSS | 174.7 MB | 28.5 MB |
| collector import per traced process | 83.3 MB / 342 ms | 25.9 MB / 59 ms |

Results are identical throughout (473/473 features).

- Features were rebuilt on every hit, each formatting enums into a name; now cached per analysis object.
- Every event was offered to all 17 factories; they declare `EVENT_TYPES` and are dispatched on it.
- `Model.handle_event` built a set of analysis objects per event that every caller discarded.
- `FeatureBuilder.hit` skips a feature this run has already recorded, which is sound only because `set_feature` keeps the first value.
- **A real leak:** `DefUseFactory` kept one dict, and every `DefEvent` in it, per scope id — and scope ids are handed out per call, so a 20k-call run retained 180,575 events. Factories now get an `exit_scope` hook.
- Def-use resolution walks the scope chain, as the language does, instead of consulting only the innermost scope plus an unbounded global map that could match a recycled `id()`. Attributes are exempt: `self.x` outlives the constructor's scope.
- `pandas`, `numpy` and the language backends are built or imported on first use, because this package is loaded into every traced process where they are never touched.

## Parallelism

Analysis is Python-level work, so threads cannot help. `Analyzer(processes=N)` and `EventHandler(processes=N)` deal runs out to worker processes and merge their per-run state before scoring: **3.2-3.5x on four processes**, with results identical to a single process.

## Fix

`ParallelModel.prepare` rebound its scope maps instead of keying them per event file, so the first def or use carrying a thread id raised `KeyError`.

## Tests

302 pass locally. New coverage for the tracer (both backends, against the instrumented trace as oracle), the budgets, artifact merging, process-parallel analysis and building, and the scope-release and def-use resolution behaviour.